### PR TITLE
feat: Add annotations field to ConversationMessage

### DIFF
--- a/apps/assistant-backend/pyproject.toml
+++ b/apps/assistant-backend/pyproject.toml
@@ -78,6 +78,7 @@ ENVIRONMENT = 'development'
 LLM_BASE_URL = 'http://localhost'
 DATABASE_URL = 'sqlite+aiosqlite:///:memory:'
 CHROMA_HOST = 'http://localhost'
+CLIENT_ORIGINS = []
 
 
 

--- a/apps/assistant-backend/src/assistant/models/annotations.py
+++ b/apps/assistant-backend/src/assistant/models/annotations.py
@@ -1,0 +1,51 @@
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class ToolAnnotationStatus(StrEnum):
+    COMPLETED = 'completed'
+    FAILED = 'failed'
+
+
+class FailureAnnotationStage(StrEnum):
+    LLM = 'llm'
+    TOOL = 'tool'
+    ANNOTATION = 'annotation'
+    UNKNOWN = 'unknown'
+
+
+class SourceAnnotation(BaseModel):
+    title: str
+    url: str
+    snippet: str
+    rationale: str
+
+
+class ToolAnnotation(BaseModel):
+    name: str
+    status: ToolAnnotationStatus
+
+
+class MemoryHitAnnotation(BaseModel):
+    label: str
+    summary: str
+
+
+class MemorySavedAnnotation(BaseModel):
+    label: str
+    summary: str
+
+
+class FailureAnnotation(BaseModel):
+    stage: FailureAnnotationStage
+    retryable: bool = False
+    detail: str | None = None
+
+
+class AssistantAnnotations(BaseModel):
+    sources: list[SourceAnnotation] = Field(default_factory=list)
+    tools: list[ToolAnnotation] = Field(default_factory=list)
+    memory_hits: list[MemoryHitAnnotation] = Field(default_factory=list)
+    memory_saved: list[MemorySavedAnnotation] = Field(default_factory=list)
+    failure: FailureAnnotation | None = None

--- a/apps/assistant-backend/src/assistant/models/conversation.py
+++ b/apps/assistant-backend/src/assistant/models/conversation.py
@@ -4,6 +4,8 @@ import uuid
 
 from pydantic import BaseModel, Field
 
+from assistant.models.annotations import AssistantAnnotations
+
 
 class ConversationSummary(BaseModel):
     id: uuid.UUID
@@ -19,6 +21,7 @@ class MessageRead(BaseModel):
     sequence_number: int
     created_at: datetime
     error: str | None = None
+    annotations: AssistantAnnotations | None = None
 
 
 class CreateConversationWithMessageRequest(BaseModel):

--- a/apps/assistant-backend/src/assistant/models/conversation_sql.py
+++ b/apps/assistant-backend/src/assistant/models/conversation_sql.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Text,
     func,
 )
+from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -101,5 +102,8 @@ class Message(SQLModel, table=True):
         default=None,
         sa_column=Column(Text, nullable=True),
     )
-
+    annotations: dict | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+    )
     conversation: Conversation = Relationship(back_populates='messages')

--- a/apps/assistant-backend/src/assistant/models/conversation_sql.py
+++ b/apps/assistant-backend/src/assistant/models/conversation_sql.py
@@ -15,6 +15,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Field, Relationship, SQLModel
 
+from assistant.models.annotations import AssistantAnnotations
+
 
 class Conversation(SQLModel, table=True):
     __tablename__ = 'conversations'  # type: ignore[assignment]
@@ -102,7 +104,7 @@ class Message(SQLModel, table=True):
         default=None,
         sa_column=Column(Text, nullable=True),
     )
-    annotations: dict | None = Field(
+    annotations: AssistantAnnotations | None = Field(
         default=None,
         sa_column=Column(JSON, nullable=True),
     )

--- a/apps/assistant-backend/src/assistant/models/conversation_sql.py
+++ b/apps/assistant-backend/src/assistant/models/conversation_sql.py
@@ -3,6 +3,7 @@ from typing import Literal
 import uuid
 
 from sqlalchemy import (
+    JSON,
     CheckConstraint,
     Column,
     DateTime,
@@ -11,7 +12,6 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Field, Relationship, SQLModel
 

--- a/apps/assistant-backend/src/assistant/models/memory.py
+++ b/apps/assistant-backend/src/assistant/models/memory.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+import uuid
+
+from pydantic import BaseModel
+
+from assistant.models.memory_sql import (
+    DurableFactConfidence,
+    DurableFactSourceType,
+)
+
+
+class ConversationMemorySummaryRead(BaseModel):
+    id: uuid.UUID
+    conversation_id: uuid.UUID
+    user_id: str
+    summary_text: str
+    source_message_id: uuid.UUID | None = None
+    version: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class DurableFactRead(BaseModel):
+    id: uuid.UUID
+    user_id: str
+    subject: str
+    fact_key: str | None = None
+    fact_text: str
+    confidence: DurableFactConfidence
+    source_type: DurableFactSourceType
+    source_conversation_id: uuid.UUID | None = None
+    source_message_id: uuid.UUID | None = None
+    source_excerpt: str | None = None
+    active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class UpsertConversationMemorySummaryRequest(BaseModel):
+    conversation_id: uuid.UUID
+    user_id: str
+    summary_text: str
+    source_message_id: uuid.UUID | None = None
+
+
+class CreateDurableFactRequest(BaseModel):
+    user_id: str
+    subject: str
+    fact_key: str | None = None
+    fact_text: str
+    confidence: DurableFactConfidence
+    source_type: DurableFactSourceType
+    source_conversation_id: uuid.UUID | None = None
+    source_message_id: uuid.UUID | None = None
+    source_excerpt: str | None = None
+
+
+class DurableFactCandidate(BaseModel):
+    subject: str
+    fact_key: str | None = None
+    fact_text: str
+    confidence: DurableFactConfidence
+    source_type: DurableFactSourceType
+    source_excerpt: str | None = None

--- a/apps/assistant-backend/src/assistant/models/memory_sql.py
+++ b/apps/assistant-backend/src/assistant/models/memory_sql.py
@@ -1,0 +1,169 @@
+from datetime import datetime
+from enum import StrEnum
+import uuid
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlmodel import Field, SQLModel
+
+
+class DurableFactConfidence(StrEnum):
+    LOW = 'low'
+    MEDIUM = 'medium'
+    HIGH = 'high'
+
+
+class DurableFactSourceType(StrEnum):
+    CONVERSATION = 'conversation'
+    TOOL = 'tool'
+    USER_EXPLICIT = 'user_explicit'
+
+
+class ConversationMemorySummary(SQLModel, table=True):
+    __tablename__ = 'conversation_memory_summaries'  # type: ignore[assignment]
+    __table_args__ = (
+        UniqueConstraint(
+            'conversation_id',
+            name='conversation_memory_summaries_conversation_id_key',
+        ),
+        Index(
+            'conversation_memory_summaries_user_updated_idx',
+            'user_id',
+            'updated_at',
+        ),
+    )
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(UUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    conversation_id: uuid.UUID = Field(
+        foreign_key='conversations.id',
+        nullable=False,
+    )
+    user_id: str = Field(
+        sa_column=Column(String(255), nullable=False, index=True),
+    )
+    summary_text: str = Field(
+        sa_column=Column(Text, nullable=False),
+    )
+    source_message_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key='messages.id',
+        nullable=True,
+    )
+    version: int = Field(
+        default=1,
+        sa_column=Column(Integer, nullable=False, server_default='1'),
+    )
+    created_at: datetime = Field(
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+        ),
+    )
+    updated_at: datetime = Field(
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+            onupdate=func.now(),
+        ),
+    )
+
+
+class DurableFact(SQLModel, table=True):
+    __tablename__ = 'durable_facts'  # type: ignore[assignment]
+    __table_args__ = (
+        Index(
+            'durable_facts_user_active_updated_idx',
+            'user_id',
+            'active',
+            'updated_at',
+        ),
+        Index(
+            'durable_facts_user_subject_idx',
+            'user_id',
+            'subject',
+        ),
+        Index(
+            'durable_facts_user_fact_key_active_idx',
+            'user_id',
+            'fact_key',
+            'active',
+        ),
+        Index('durable_facts_source_message_idx', 'source_message_id'),
+    )
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(UUID(as_uuid=True), primary_key=True, nullable=False),
+    )
+    user_id: str = Field(
+        sa_column=Column(String(255), nullable=False, index=True),
+    )
+    subject: str = Field(
+        sa_column=Column(String(255), nullable=False),
+    )
+    fact_key: str | None = Field(
+        default=None,
+        sa_column=Column(String(255), nullable=True),
+    )
+    fact_text: str = Field(
+        sa_column=Column(Text, nullable=False),
+    )
+    confidence: DurableFactConfidence = Field(
+        sa_column=Column(String(32), nullable=False),
+    )
+    source_type: DurableFactSourceType = Field(
+        sa_column=Column(String(32), nullable=False),
+    )
+    source_conversation_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key='conversations.id',
+        nullable=True,
+    )
+    source_message_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key='messages.id',
+        nullable=True,
+    )
+    source_excerpt: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+    )
+    active: bool = Field(
+        default=True,
+        sa_column=Column(
+            Boolean,
+            nullable=False,
+            server_default=text('true'),
+        ),
+    )
+    created_at: datetime = Field(
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+        ),
+    )
+    updated_at: datetime = Field(
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+            onupdate=func.now(),
+        ),
+    )

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -353,4 +353,5 @@ class ConversationService:
             sequence_number=message.sequence_number,
             created_at=message.created_at,
             error=message.error,
+            annotations=message.annotations,
         )

--- a/apps/assistant-backend/tests/models/test_memory_models.py
+++ b/apps/assistant-backend/tests/models/test_memory_models.py
@@ -1,0 +1,211 @@
+"""Tests for canonical memory models."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from assistant.models.conversation_sql import Conversation
+from assistant.models.memory import (
+    ConversationMemorySummaryRead,
+    CreateDurableFactRequest,
+    DurableFactCandidate,
+    DurableFactRead,
+    UpsertConversationMemorySummaryRequest,
+)
+from assistant.models.memory_sql import (
+    ConversationMemorySummary,
+    DurableFact,
+    DurableFactConfidence,
+    DurableFactSourceType,
+)
+
+
+@pytest_asyncio.fixture
+async def async_session():
+    """Create an in-memory SQLite database session for testing."""
+    engine = create_async_engine(
+        'sqlite+aiosqlite:///:memory:',
+        echo=False,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async with async_session_maker() as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_conversation_memory_summary_defaults(async_session):
+    """It persists a single latest summary with sensible defaults."""
+    conversation = Conversation(
+        user_id='user-123',
+        title='Research George Langley',
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    summary = ConversationMemorySummary(
+        conversation_id=conversation.id,
+        user_id=conversation.user_id,
+        summary_text='The user is researching George Langley census records.',
+    )
+    async_session.add(summary)
+    await async_session.commit()
+
+    stmt = select(ConversationMemorySummary).where(
+        ConversationMemorySummary.id == summary.id
+    )
+    result = await async_session.execute(stmt)
+    persisted = result.scalar_one()
+
+    assert persisted.version == 1
+    assert persisted.source_message_id is None
+    assert persisted.summary_text.startswith('The user is researching')
+    assert persisted.created_at is not None
+    assert persisted.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_conversation_memory_summary_requires_unique_conversation(
+    async_session,
+):
+    """It only allows one canonical summary row per conversation."""
+    conversation = Conversation(
+        user_id='user-123',
+        title='Family tree',
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    first = ConversationMemorySummary(
+        conversation_id=conversation.id,
+        user_id=conversation.user_id,
+        summary_text='Initial summary',
+    )
+    second = ConversationMemorySummary(
+        conversation_id=conversation.id,
+        user_id=conversation.user_id,
+        summary_text='Duplicate summary',
+    )
+
+    async_session.add(first)
+    await async_session.commit()
+
+    async_session.add(second)
+    with pytest.raises(IntegrityError):
+        await async_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_durable_fact_defaults(async_session):
+    """It persists a durable fact with default active state."""
+    fact = DurableFact(
+        user_id='user-123',
+        subject='user',
+        fact_key='user.home_city',
+        fact_text='User lives in Sydney.',
+        confidence=DurableFactConfidence.HIGH,
+        source_type=DurableFactSourceType.CONVERSATION,
+    )
+    async_session.add(fact)
+    await async_session.commit()
+
+    stmt = select(DurableFact).where(DurableFact.id == fact.id)
+    result = await async_session.execute(stmt)
+    persisted = result.scalar_one()
+
+    assert persisted.active is True
+    assert persisted.fact_key == 'user.home_city'
+    assert persisted.confidence == DurableFactConfidence.HIGH
+    assert persisted.source_type == DurableFactSourceType.CONVERSATION
+    assert persisted.source_excerpt is None
+    assert persisted.created_at is not None
+    assert persisted.updated_at is not None
+
+
+def test_memory_read_models_preserve_fields():
+    """It exposes stable typed read models for services and APIs."""
+    now = datetime(2026, 4, 13, 8, 30, tzinfo=timezone.utc)
+    conversation_id = uuid.uuid4()
+    message_id = uuid.uuid4()
+    fact_id = uuid.uuid4()
+
+    summary = ConversationMemorySummaryRead(
+        id=uuid.uuid4(),
+        conversation_id=conversation_id,
+        user_id='user-123',
+        summary_text='Summary text',
+        source_message_id=message_id,
+        version=2,
+        created_at=now,
+        updated_at=now,
+    )
+    fact = DurableFactRead(
+        id=fact_id,
+        user_id='user-123',
+        subject='person.george_langley',
+        fact_key='person.george_langley.birth_year',
+        fact_text='George Langley was born in 1884.',
+        confidence=DurableFactConfidence.MEDIUM,
+        source_type=DurableFactSourceType.TOOL,
+        source_conversation_id=conversation_id,
+        source_message_id=message_id,
+        source_excerpt='1911 census lists age 27.',
+        active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+    assert summary.version == 2
+    assert summary.source_message_id == message_id
+    assert fact.confidence == DurableFactConfidence.MEDIUM
+    assert fact.source_type == DurableFactSourceType.TOOL
+    assert fact.fact_key == 'person.george_langley.birth_year'
+
+
+def test_memory_write_models_capture_extraction_outputs():
+    """It provides typed request and candidate shapes for extraction flows."""
+    summary_request = UpsertConversationMemorySummaryRequest(
+        conversation_id=uuid.uuid4(),
+        user_id='user-123',
+        summary_text='Refreshed summary',
+    )
+    fact_request = CreateDurableFactRequest(
+        user_id='user-123',
+        subject='user',
+        fact_key='user.preference.primary_sources',
+        fact_text='User prefers primary sources over summaries.',
+        confidence=DurableFactConfidence.HIGH,
+        source_type=DurableFactSourceType.USER_EXPLICIT,
+        source_excerpt='Please use primary records whenever possible.',
+    )
+    candidate = DurableFactCandidate(
+        subject='person.george_langley',
+        fact_key='person.george_langley.birth_year',
+        fact_text='George Langley was born in 1884.',
+        confidence=DurableFactConfidence.MEDIUM,
+        source_type=DurableFactSourceType.TOOL,
+        source_excerpt='1911 census age suggests 1884 birth year.',
+    )
+
+    assert summary_request.summary_text == 'Refreshed summary'
+    assert fact_request.source_type == DurableFactSourceType.USER_EXPLICIT
+    assert fact_request.fact_key == 'user.preference.primary_sources'
+    assert candidate.confidence == DurableFactConfidence.MEDIUM
+    assert candidate.source_excerpt is not None

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -157,6 +157,7 @@ describe("ConversationsChat", () => {
           sequence_number: 1,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-2",
@@ -165,6 +166,7 @@ describe("ConversationsChat", () => {
           sequence_number: 2,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
       };
 
@@ -221,6 +223,7 @@ describe("ConversationsChat", () => {
           sequence_number: 1,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-2",
@@ -229,6 +232,7 @@ describe("ConversationsChat", () => {
           sequence_number: 2,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
       };
 
@@ -303,6 +307,7 @@ describe("ConversationsChat", () => {
           sequence_number: 1,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-2",
@@ -311,6 +316,7 @@ describe("ConversationsChat", () => {
           sequence_number: 2,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
       };
 
@@ -369,6 +375,7 @@ describe("ConversationsChat", () => {
             sequence_number: 1,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
           },
           {
             id: "msg-2",
@@ -377,6 +384,7 @@ describe("ConversationsChat", () => {
             sequence_number: 2,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
           },
         ],
       };
@@ -435,6 +443,7 @@ describe("ConversationsChat", () => {
             sequence_number: 1,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
           },
           {
             id: "msg-2",
@@ -443,6 +452,7 @@ describe("ConversationsChat", () => {
             sequence_number: 2,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
           },
         ],
       };
@@ -461,6 +471,7 @@ describe("ConversationsChat", () => {
           sequence_number: 3,
           created_at: "2024-01-01T00:01:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-4",
@@ -469,6 +480,7 @@ describe("ConversationsChat", () => {
           sequence_number: 4,
           created_at: "2024-01-01T00:01:00Z",
           error: null,
+          annotations: null,
         },
       };
 
@@ -579,6 +591,7 @@ describe("ConversationsChat", () => {
             sequence_number: 1,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
           },
         ],
       };
@@ -691,6 +704,7 @@ describe("ConversationsChat", () => {
           sequence_number: 1,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-2",
@@ -699,6 +713,7 @@ describe("ConversationsChat", () => {
           sequence_number: 2,
           created_at: "2024-01-01T00:00:00Z",
           error: "LLM service unavailable",
+          annotations: null,
         },
       };
 

--- a/apps/assistant-ui/src/types/api.ts
+++ b/apps/assistant-ui/src/types/api.ts
@@ -36,6 +36,46 @@ export interface ChatResponse {
 }
 
 /**
+ * Annotations for message responses.
+ */
+
+export interface SourceAnnotation {
+  title: string;
+  url: string;
+  snippet: string;
+  rationale: string;
+}
+
+export interface ToolAnnotation {
+  name: string;
+  status: "completed" | "failed";
+}
+
+export interface MemoryHitAnnotation {
+  label: string;
+  summary: string;
+}
+
+export interface MemorySavedAnnotation {
+  label: string;
+  summary: string;
+}
+
+export interface FailureAnnotation {
+  stage: "llm" | "tool" | "annotation" | "unknown";
+  retryable: boolean;
+  detail: string | null;
+}
+
+export interface AssistantAnnotations {
+  sources: SourceAnnotation[];
+  tools: ToolAnnotation[];
+  memory_hits: MemoryHitAnnotation[];
+  memory_saved: MemorySavedAnnotation[];
+  failure: FailureAnnotation | null;
+}
+
+/**
  * Conversation types matching the backend Conversation models
  */
 export interface ConversationSummary {
@@ -52,6 +92,7 @@ export interface Message {
   sequence_number: number;
   created_at: string;
   error: string | null;
+  annotations: AssistantAnnotations | null;
 }
 
 export interface CreateConversationRequest {

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -244,8 +244,8 @@ They keep trust payloads useful instead of bloated.
 - ✅ update [apps/assistant-backend/src/assistant/models/conversation_sql.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation_sql.py)
 - ✅ update [apps/assistant-backend/src/assistant/models/conversation.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation.py)
 - ✅ add annotations models: [apps/assistant-backend/src/assistant/models/annotations.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/annotations.py)
-- ⏳ add memory SQLModel file, for example `apps/assistant-backend/src/assistant/models/memory_sql.py`
-- ⏳ add memory API model file, for example `apps/assistant-backend/src/assistant/models/memory.py`
+- ✅ add memory SQLModel file, for example `apps/assistant-backend/src/assistant/models/memory_sql.py`
+- ✅ add memory API model file, for example `apps/assistant-backend/src/assistant/models/memory.py`
 - ⏳ add Alembic scaffold and migrations under `apps/assistant-backend/`
 - ✅ update [apps/assistant-ui/src/types/api.ts](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-ui/src/types/api.ts)
 
@@ -253,7 +253,7 @@ They keep trust payloads useful instead of bloated.
 
 - ✅ add `annotations` to persisted assistant messages
 - ✅ add Pydantic models for annotation payloads (`AssistantAnnotations`, `SourceAnnotation`, `ToolAnnotation`, `MemoryHitAnnotation`, `MemorySavedAnnotation`, `FailureAnnotation`)
-- ⏳ add summary and durable-fact tables
+- ✅ add summary and durable-fact tables
 - ✅ extend TypeScript `Message` shape to include `annotations`
 
 **Acceptance criteria**
@@ -268,11 +268,11 @@ They keep trust payloads useful instead of bloated.
 - Extended `MessageRead` API contract to include annotations
 - Added matching TypeScript types for all annotation structures
 - Updated frontend test mocks to handle nullable annotations
+- Created conversation summary and durable fact SQLModel tables
+- Created corresponding Pydantic API models for memory operations
 
 **Remaining work:**
 - Create Alembic migration for the `annotations` column addition
-- Add conversation summary and durable fact SQLModel tables
-- Add corresponding Pydantic API models for memory operations
 
 ### Step 2. Extract the shared LLM completion seam
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -237,27 +237,42 @@ They keep trust payloads useful instead of bloated.
 
 ### Step 1. Add backend schema and API contracts
 
+**Status:** 🔄 **IN PROGRESS** (~70% complete)
+
 **Files**
 
-- update [apps/assistant-backend/src/assistant/models/conversation_sql.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation_sql.py)
-- update [apps/assistant-backend/src/assistant/models/conversation.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation.py)
-- add memory SQLModel file, for example `apps/assistant-backend/src/assistant/models/memory_sql.py`
-- add memory API model file, for example `apps/assistant-backend/src/assistant/models/memory.py`
-- add Alembic scaffold and migrations under `apps/assistant-backend/`
-- update [apps/assistant-ui/src/types/api.ts](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-ui/src/types/api.ts)
+- ✅ update [apps/assistant-backend/src/assistant/models/conversation_sql.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation_sql.py)
+- ✅ update [apps/assistant-backend/src/assistant/models/conversation.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/conversation.py)
+- ✅ add annotations models: [apps/assistant-backend/src/assistant/models/annotations.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/models/annotations.py)
+- ⏳ add memory SQLModel file, for example `apps/assistant-backend/src/assistant/models/memory_sql.py`
+- ⏳ add memory API model file, for example `apps/assistant-backend/src/assistant/models/memory.py`
+- ⏳ add Alembic scaffold and migrations under `apps/assistant-backend/`
+- ✅ update [apps/assistant-ui/src/types/api.ts](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-ui/src/types/api.ts)
 
 **Work**
 
-- add `annotations` to persisted assistant messages
-- add Pydantic models for annotation payloads
-- add summary and durable-fact tables
-- extend TypeScript `Message` shape to include `annotations`
+- ✅ add `annotations` to persisted assistant messages
+- ✅ add Pydantic models for annotation payloads (`AssistantAnnotations`, `SourceAnnotation`, `ToolAnnotation`, `MemoryHitAnnotation`, `MemorySavedAnnotation`, `FailureAnnotation`)
+- ⏳ add summary and durable-fact tables
+- ✅ extend TypeScript `Message` shape to include `annotations`
 
 **Acceptance criteria**
 
-- backend can serialize assistant messages with `annotations: null | object`
-- schema migration path exists for existing Postgres installs
-- frontend type layer can represent all phase-1 trust payloads
+- ✅ backend can serialize assistant messages with `annotations: null | object`
+- ⏳ schema migration path exists for existing Postgres installs
+- ✅ frontend type layer can represent all phase-1 trust payloads
+
+**Completed work:**
+- Added nullable `annotations` JSON field to `Message` table (conversation_sql.py)
+- Created comprehensive annotation models with proper type enums and Pydantic validation
+- Extended `MessageRead` API contract to include annotations
+- Added matching TypeScript types for all annotation structures
+- Updated frontend test mocks to handle nullable annotations
+
+**Remaining work:**
+- Create Alembic migration for the `annotations` column addition
+- Add conversation summary and durable fact SQLModel tables
+- Add corresponding Pydantic API models for memory operations
 
 ### Step 2. Extract the shared LLM completion seam
 


### PR DESCRIPTION
## Summary

Implements the foundation of Phase 1, Step 1 from the implementation plan: adding annotations infrastructure for assistant messages.

This PR establishes the data model and type contracts needed to support trust annotations (sources, tool usage, memory hits, failure details) on assistant responses.

## Changes

### Backend
- **New annotations models** ([annotations.py](apps/assistant-backend/src/assistant/models/annotations.py))
  - `AssistantAnnotations` - Container for all annotation types
  - `SourceAnnotation` - Evidence/source citations
  - `ToolAnnotation` - Tool usage tracking
  - `MemoryHitAnnotation` / `MemorySavedAnnotation` - Memory operation feedback
  - `FailureAnnotation` - Structured error metadata
- **Database schema** - Added nullable `annotations` JSON column to `Message` table
- **API contract** - Extended `MessageRead` to include `annotations: AssistantAnnotations | null`

### Frontend
- **TypeScript types** - Mirrored all backend annotation structures in [api.ts](apps/assistant-ui/src/types/api.ts)
- **Test updates** - Updated all message mocks to include `annotations: null`

## Implementation Status

This completes ~70% of Step 1:
- ✅ Annotations infrastructure (models, schema, types)
- ⏳ Alembic migration (deferred - will add when first populated)
- ⏳ Memory tables (conversation summaries, durable facts - next PR)

See [IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md) for full tracking.

## Testing

- All backend tests pass (pytest)
- All frontend tests pass (vitest)
- Type checking passes on both frontend and backend

## Documentation

**IMPLEMENTATION_PLAN.md:** Updated Step 1 with progress tracking
- Added status indicators (✅ complete, ⏳ remaining)
- Documented completed work: annotations models, DB schema, API contracts, TypeScript types
- Documented remaining work: Alembic migrations, memory tables
- Added ~70% completion marker with detailed breakdown