### PR TITLE
feat(backend): add initial tool layer and current time tool

### DIFF
--- a/apps/assistant-backend/README.md
+++ b/apps/assistant-backend/README.md
@@ -16,6 +16,9 @@ and an external llama.cpp server for LLM inference.
 * **LLM chat completions** — proxies chat requests to a local llama.cpp server
 * **Shared LLM completion seam** — one typed backend path now powers both the direct chat endpoint and conversation replies, with common response validation and error handling
 * **Bounded conversation context assembly** — existing conversation replies now use the latest saved summary, active per-user durable facts, and a capped recent-turn window instead of blindly resending the full transcript
+* **Initial tool layer** — `BaseTool`, `ToolFactory`, and `ToolService` now provide one explicit backend tool seam with typed execution results and shared allowlist-based dispatch
+* **Bounded native tool loop** — conversation replies can now expose allowed tools to the model, execute requested tool calls, and feed tool outputs back through a capped multi-round completion loop
+* **Deterministic validation tool** — `get_current_time` is shipped as the first backend tool so the tool path can be verified end to end before adding real `web_search` + `web_fetch` research tools
 * **Conversation management** — create conversations, add messages, list and retrieve history
 * **Health check endpoint**
 * **PostgreSQL storage** — async SQLModel / SQLAlchemy with automatic schema creation

--- a/apps/assistant-backend/src/assistant/constants.py
+++ b/apps/assistant-backend/src/assistant/constants.py
@@ -3,3 +3,5 @@ SYSTEM_PROMPT = (
     "Answer the user's questions clearly and concisely. If you are unsure "
     'about something, say so rather than guessing.'
 )
+
+MAXIMUM_TOOL_ROUNDS = 3

--- a/apps/assistant-backend/src/assistant/models/tool.py
+++ b/apps/assistant-backend/src/assistant/models/tool.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -18,7 +18,7 @@ class ToolCallRecord(BaseModel):
     """Metadata about one concrete tool execution."""
 
     name: str
-    arguments: dict
+    arguments: dict[str, Any]
     started_at: datetime
     finished_at: datetime
     status: ToolExecutionStatus
@@ -81,6 +81,6 @@ class ToolExecutionResult(BaseModel):
     status: ToolExecutionStatus
     tool_call: ToolCallRecord
     llm_context: str | None = None
-    annotation_inputs: dict | None = None
+    annotation_inputs: dict[str, Any] | None = None
     payload: ToolPayload | None = None
     error: ToolError | None = None

--- a/apps/assistant-backend/src/assistant/models/tool.py
+++ b/apps/assistant-backend/src/assistant/models/tool.py
@@ -1,0 +1,86 @@
+"""Shared models for tool definitions, execution metadata, and payloads."""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class ToolExecutionStatus(StrEnum):
+    """Normalized status values returned by all tools."""
+
+    SUCCESS = 'success'
+    ERROR = 'error'
+
+
+class ToolCallRecord(BaseModel):
+    """Metadata about one concrete tool execution."""
+
+    name: str
+    arguments: dict
+    started_at: datetime
+    finished_at: datetime
+    status: ToolExecutionStatus
+
+
+class TimePayload(BaseModel):
+    """Structured payload for the current-time tool."""
+
+    kind: Literal['get_current_time']
+    iso_timestamp: str
+    display_text: str
+
+
+class WebSearchPayload(BaseModel):
+    """Structured payload for a single web search result."""
+
+    kind: Literal['web_search']
+    title: str
+    url: str
+    snippet: str | None = None
+
+
+class WebFetchPayload(BaseModel):
+    """Structured payload for fetched page content."""
+
+    kind: Literal['web_fetch']
+    url: str
+    title: str | None = None
+    content: str
+    excerpt: str | None = None
+
+
+class ImageGenerationPayload(BaseModel):
+    """Structured payload for generated image artifacts."""
+
+    kind: Literal['image_generate']
+    asset_url: str
+    prompt: str
+    revised_prompt: str | None = None
+    mime_type: str = 'image/png'
+
+
+class ToolError(BaseModel):
+    """Normalized error shape returned by tool executions."""
+
+    code: str
+    message: str
+    retryable: bool = False
+
+
+ToolPayload = (
+    WebSearchPayload | WebFetchPayload | ImageGenerationPayload | TimePayload
+)
+
+
+class ToolExecutionResult(BaseModel):
+    """Stable envelope returned by every tool execution."""
+
+    tool_name: str
+    status: ToolExecutionStatus
+    tool_call: ToolCallRecord
+    llm_context: str | None = None
+    annotation_inputs: dict | None = None
+    payload: ToolPayload | None = None
+    error: ToolError | None = None

--- a/apps/assistant-backend/src/assistant/services/__init__.py
+++ b/apps/assistant-backend/src/assistant/services/__init__.py
@@ -4,7 +4,18 @@ from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.conversation_service import ConversationService
 from assistant.services.llm_service import LLMService
 from assistant.services.memory_storage import MemoryStorage
+from assistant.services.tool_service import ToolService
+from assistant.services.tools.current_time import CurrentTimeTool
+from assistant.services.tools.factory import ToolFactory
 from assistant.settings import settings
+
+
+@lru_cache(maxsize=1)
+def get_tool_service() -> ToolService:
+    """Return a lazily initialized singleton instance of ToolService."""
+    # Initialize tools here - for now we have none, but this is where you'd add them.
+    factory = ToolFactory(tools=[CurrentTimeTool()])
+    return ToolService(factory=factory)
 
 
 @lru_cache(maxsize=1)
@@ -38,4 +49,5 @@ def get_conversation_service() -> ConversationService:
     return ConversationService(
         llm_service=get_llm_service(),
         context_assembly=get_context_assembly_service(),
+        tool_service=get_tool_service(),
     )

--- a/apps/assistant-backend/src/assistant/services/__init__.py
+++ b/apps/assistant-backend/src/assistant/services/__init__.py
@@ -13,7 +13,7 @@ from assistant.settings import settings
 @lru_cache(maxsize=1)
 def get_tool_service() -> ToolService:
     """Return a lazily initialized singleton instance of ToolService."""
-    # Initialize tools here - for now we have none, but this is where you'd add them.
+    # Register tools here. Currently, only CurrentTimeTool is wired in.
     factory = ToolFactory(tools=[CurrentTimeTool()])
     return ToolService(factory=factory)
 

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -371,7 +371,7 @@ class ConversationService:
                         {
                             'role': 'tool',
                             'tool_call_id': tool_call.id,
-                            'content': tool_result.llm_context,
+                            'content': tool_result.llm_context or '',
                         }
                     )
 

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,3 +1,4 @@
+import json
 from typing import cast
 import uuid
 
@@ -5,7 +6,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from assistant.constants import SYSTEM_PROMPT
+from assistant.constants import MAXIMUM_TOOL_ROUNDS, SYSTEM_PROMPT
 from assistant.models.conversation import (
     ConversationSummary,
     ConversationWithMessagesResponse,
@@ -23,6 +24,10 @@ from assistant.models.llm import (
 from assistant.routers.web_utils import llm_completion_error_to_http_exception
 from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.llm_service import LLMService
+from assistant.services.tool_service import ToolService
+from assistant.services.tools.errors import (
+    UnsupportedToolError,
+)
 from assistant.settings import settings
 
 
@@ -36,9 +41,11 @@ class ConversationService:
         self,
         llm_service: LLMService,
         context_assembly: ContextAssemblyService,
+        tool_service: ToolService,
     ) -> None:
         self.llm_service = llm_service
         self.context_assembly = context_assembly
+        self.tool_service = tool_service
 
     async def list_conversations(
         self,
@@ -301,18 +308,79 @@ class ConversationService:
             role='system', content=SYSTEM_PROMPT
         )
         llm_messages = [system_message.model_dump()] + messages
+        tools = self.tool_service.get_available_tools()
 
-        try:
-            result = await self.llm_service.complete_messages(
-                messages=llm_messages,
-                model=settings.llm_model,
-                temperature=temperature,
-                max_tokens=max_tokens,
-            )
-        except LLMCompletionError as exc:
-            raise llm_completion_error_to_http_exception(exc) from exc
+        for _ in range(MAXIMUM_TOOL_ROUNDS):
+            try:
+                result = await self.llm_service.complete_messages(
+                    messages=llm_messages,
+                    model=settings.llm_model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice='auto',
+                )
+                if not result.tool_calls:
+                    return result.content
 
-        return result.content
+                llm_messages.append(
+                    {
+                        'role': 'assistant',
+                        'content': result.content,
+                        'tool_calls': result.tool_calls,
+                    }
+                )
+
+                for tool_call in result.tool_calls:
+                    # Parse and validate tool arguments safely
+                    try:
+                        parsed_arguments = json.loads(
+                            tool_call.function.arguments
+                        )
+                        # Validate parsed arguments are a dict
+                        if not isinstance(parsed_arguments, dict):
+                            raise ValueError(
+                                f'Tool arguments must be a JSON object, '
+                                f'got {type(parsed_arguments).__name__}'
+                            )
+                    except json.JSONDecodeError as exc:
+                        raise HTTPException(
+                            status_code=status.HTTP_502_BAD_GATEWAY,
+                            detail=(
+                                f'Invalid tool arguments JSON: '
+                                f'{tool_call.function.name}'
+                            ),
+                        ) from exc
+                    except ValueError as exc:
+                        raise HTTPException(
+                            status_code=status.HTTP_502_BAD_GATEWAY,
+                            detail=str(exc),
+                        ) from exc
+
+                    tool_result = await self.tool_service.execute_tool(
+                        name=tool_call.function.name,
+                        arguments=parsed_arguments,
+                    )
+                    llm_messages.append(
+                        {
+                            'role': 'tool',
+                            'tool_call_id': tool_call.id,
+                            'content': tool_result.llm_context,
+                        }
+                    )
+
+            except LLMCompletionError as exc:
+                raise llm_completion_error_to_http_exception(exc) from exc
+            except UnsupportedToolError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=str(exc),
+                ) from exc
+
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f'Assistant exceeded maximum tool rounds ({MAXIMUM_TOOL_ROUNDS})',
+        )
 
     @staticmethod
     def _conversation_summary(

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -312,13 +312,18 @@ class ConversationService:
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
             try:
+                completion_kwargs = {
+                    'messages': llm_messages,
+                    'model': settings.llm_model,
+                    'temperature': temperature,
+                    'max_tokens': max_tokens,
+                }
+                if tools:
+                    completion_kwargs['tools'] = tools
+                    completion_kwargs['tool_choice'] = 'auto'
+
                 result = await self.llm_service.complete_messages(
-                    messages=llm_messages,
-                    model=settings.llm_model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    tool_choice='auto',
+                    **completion_kwargs
                 )
                 if not result.tool_calls:
                     return result.content

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -27,6 +27,7 @@ from assistant.services.llm_service import LLMService
 from assistant.services.tool_service import ToolService
 from assistant.services.tools.errors import (
     UnsupportedToolError,
+    ToolLoopExhaustedError,
 )
 from assistant.settings import settings
 

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -25,10 +25,6 @@ from assistant.routers.web_utils import llm_completion_error_to_http_exception
 from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.llm_service import LLMService
 from assistant.services.tool_service import ToolService
-from assistant.services.tools.errors import (
-    UnsupportedToolError,
-    ToolLoopExhaustedError,
-)
 from assistant.settings import settings
 
 
@@ -363,11 +359,17 @@ class ConversationService:
                             status_code=status.HTTP_502_BAD_GATEWAY,
                             detail=str(exc),
                         ) from exc
+                    try:
+                        tool_result = await self.tool_service.execute_tool(
+                            name=tool_call.function.name,
+                            arguments=parsed_arguments,
+                        )
+                    except Exception as exc:
+                        raise HTTPException(
+                            status_code=status.HTTP_502_BAD_GATEWAY,
+                            detail=f'Error executing tool {tool_call.function.name}: {str(exc)}',
+                        ) from exc
 
-                    tool_result = await self.tool_service.execute_tool(
-                        name=tool_call.function.name,
-                        arguments=parsed_arguments,
-                    )
                     llm_messages.append(
                         {
                             'role': 'tool',
@@ -378,11 +380,6 @@ class ConversationService:
 
             except LLMCompletionError as exc:
                 raise llm_completion_error_to_http_exception(exc) from exc
-            except UnsupportedToolError as exc:
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=str(exc),
-                ) from exc
 
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -308,7 +308,8 @@ class ConversationService:
             role='system', content=SYSTEM_PROMPT
         )
         llm_messages = [system_message.model_dump()] + messages
-        tools = self.tool_service.get_available_tools()
+        available_tools = self.tool_service.get_available_tools()
+        tools = available_tools if available_tools else None
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
             try:

--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -34,6 +34,8 @@ class LLMService:
         model: str,
         temperature: float,
         max_tokens: int | None,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
     ) -> LLMCompletionResult:
         """Execute a chat completion request.
 
@@ -51,7 +53,8 @@ class LLMService:
             model: Model identifier
             temperature: Sampling temperature
             max_tokens: Maximum tokens to generate
-
+            tools: Optional list of tool definitions to include in the request
+            tool_choice: Optional specification of which tool to use, if any
         Returns:
             LLMCompletionResult with content and usage stats
 
@@ -65,6 +68,8 @@ class LLMService:
             temperature=temperature,
             max_tokens=max_tokens,
             stream=False,
+            tools=tools,
+            tool_choice=tool_choice,
         )
 
         try:

--- a/apps/assistant-backend/src/assistant/services/tool_service.py
+++ b/apps/assistant-backend/src/assistant/services/tool_service.py
@@ -1,0 +1,24 @@
+"""Service layer for exposing and executing allowed tools."""
+
+from assistant.models.tool import ToolExecutionResult
+from assistant.services.tools.factory import ToolFactory
+
+
+class ToolService:
+    """Thin orchestration layer over the explicit tool factory."""
+
+    def __init__(self, factory: ToolFactory) -> None:
+        self.factory = factory
+
+    def get_available_tools(self) -> list[dict]:
+        """Return the tool definitions exposed to the model for this process."""
+
+        return self.factory.definitions()
+
+    async def execute_tool(
+        self, *, name: str, arguments: dict
+    ) -> ToolExecutionResult:
+        """Execute one named tool with already-parsed arguments."""
+
+        tool = self.factory.get(name)
+        return await tool.execute(arguments)

--- a/apps/assistant-backend/src/assistant/services/tools/__init__.py
+++ b/apps/assistant-backend/src/assistant/services/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete tool implementations and shared tool-layer helpers."""

--- a/apps/assistant-backend/src/assistant/services/tools/base.py
+++ b/apps/assistant-backend/src/assistant/services/tools/base.py
@@ -1,0 +1,26 @@
+"""Base classes and exceptions for tools."""
+
+from abc import ABC, abstractmethod
+
+from assistant.models.tool import ToolExecutionResult
+
+
+class BaseTool(ABC):
+    """Abstract contract implemented by every concrete tool."""
+
+    name: str
+
+    @abstractmethod
+    def definition(self) -> dict:
+        """Return the OpenAI-compatible tool definition exposed to the model."""
+        ...
+
+    @abstractmethod
+    async def execute(self, arguments: dict) -> ToolExecutionResult:
+        """Execute the tool and return a normalized result envelope."""
+        ...
+
+    def is_enabled(self) -> bool:
+        """Allow tools to be disabled without removing them from wiring."""
+
+        return True

--- a/apps/assistant-backend/src/assistant/services/tools/current_time.py
+++ b/apps/assistant-backend/src/assistant/services/tools/current_time.py
@@ -1,0 +1,67 @@
+"""Deterministic tool used to validate the tool layer end to end."""
+
+from datetime import UTC, datetime
+
+from assistant.models.tool import (
+    TimePayload,
+    ToolCallRecord,
+    ToolExecutionResult,
+    ToolExecutionStatus,
+)
+from assistant.services.tools.base import BaseTool
+
+
+class CurrentTimeTool(BaseTool):
+    """Return the server's current UTC time in a normalized result envelope."""
+
+    name = 'get_current_time'
+
+    def definition(self) -> dict:
+        """Expose a minimal no-argument tool definition to the model."""
+
+        return {
+            'type': 'function',
+            'function': {
+                'name': self.name,
+                'description': 'Return the current server time in ISO 8601 format.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {},
+                    'required': [],
+                    'additionalProperties': False,
+                },
+            },
+        }
+
+    async def execute(self, arguments: dict) -> ToolExecutionResult:
+        """Capture the current UTC time and format it for LLM/tool consumers."""
+
+        started_at = datetime.now(UTC)
+        now = datetime.now(UTC)
+
+        payload = TimePayload(
+            kind=self.name,
+            iso_timestamp=now.isoformat(),
+            display_text=now.strftime('%Y-%m-%d %H:%M:%S UTC'),
+        )
+
+        finished_at = datetime.now(UTC)
+
+        return ToolExecutionResult(
+            tool_name=self.name,
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name=self.name,
+                arguments=arguments,
+                started_at=started_at,
+                finished_at=finished_at,
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            llm_context=f'Current server time: {payload.display_text} ({payload.iso_timestamp})',
+            annotation_inputs={
+                'tool_name': self.name,
+                'label': 'Current time',
+            },
+            payload=payload,
+            error=None,
+        )

--- a/apps/assistant-backend/src/assistant/services/tools/errors.py
+++ b/apps/assistant-backend/src/assistant/services/tools/errors.py
@@ -1,0 +1,18 @@
+"""Exceptions used by the shared tool layer."""
+
+class UnsupportedToolError(Exception):
+    """Raised when the model requests a tool that is not in the allowlist."""
+
+    def __init__(self, tool_name: str):
+        self.tool_name = tool_name
+        super().__init__(f'Unsupported tool: {tool_name}')
+
+
+class ToolLoopExhaustedError(Exception):
+    """Raised when the assistant exceeds the configured tool-call budget."""
+
+    def __init__(self, max_rounds: int):
+        self.max_rounds = max_rounds
+        super().__init__(
+            f'Assistant exceeded maximum tool rounds ({max_rounds})'
+        )

--- a/apps/assistant-backend/src/assistant/services/tools/errors.py
+++ b/apps/assistant-backend/src/assistant/services/tools/errors.py
@@ -1,5 +1,6 @@
 """Exceptions used by the shared tool layer."""
 
+
 class UnsupportedToolError(Exception):
     """Raised when the model requests a tool that is not in the allowlist."""
 

--- a/apps/assistant-backend/src/assistant/services/tools/factory.py
+++ b/apps/assistant-backend/src/assistant/services/tools/factory.py
@@ -4,6 +4,14 @@ from assistant.services.tools.base import BaseTool
 from assistant.services.tools.errors import UnsupportedToolError
 
 
+class DisabledToolError(Exception):
+    """Raised when a supported tool is currently disabled."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f'Tool is disabled: {name}')
+
+
 class ToolFactory:
     """Own the enabled tool set for the current backend process."""
 
@@ -20,9 +28,14 @@ class ToolFactory:
         ]
 
     def get(self, name: str) -> BaseTool:
-        """Resolve one tool by name or raise a typed lookup error."""
+        """Resolve one enabled tool by name or raise a typed error."""
 
         try:
-            return self._tools[name]
+            tool = self._tools[name]
         except KeyError as exc:
             raise UnsupportedToolError(name) from exc
+
+        if not tool.is_enabled():
+            raise DisabledToolError(name)
+
+        return tool

--- a/apps/assistant-backend/src/assistant/services/tools/factory.py
+++ b/apps/assistant-backend/src/assistant/services/tools/factory.py
@@ -1,0 +1,28 @@
+"""Explicit allowlist and lookup helpers for supported tools."""
+
+from assistant.services.tools.base import BaseTool
+from assistant.services.tools.errors import UnsupportedToolError
+
+
+class ToolFactory:
+    """Own the enabled tool set for the current backend process."""
+
+    def __init__(self, tools: list[BaseTool]) -> None:
+        self._tools = {tool.name: tool for tool in tools}
+
+    def definitions(self) -> list[dict]:
+        """Return model-facing definitions for all enabled tools."""
+
+        return [
+            tool.definition()
+            for tool in self._tools.values()
+            if tool.is_enabled()
+        ]
+
+    def get(self, name: str) -> BaseTool:
+        """Resolve one tool by name or raise a typed lookup error."""
+
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise UnsupportedToolError(name) from exc

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -19,9 +19,15 @@ from assistant.models.conversation import (
 )
 from assistant.models.conversation_sql import Conversation, Message
 from assistant.models.llm import (
+    ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCallFunction,
     LLMCompletionError,
     LLMCompletionErrorKind,
     LLMCompletionResult,
+)
+from assistant.models.tool import (
+    ToolExecutionResult,
+    ToolExecutionStatus,
 )
 from assistant.services.context_assembly import (
     ContextAssemblyResult,
@@ -30,6 +36,10 @@ from assistant.services.context_assembly import (
 from assistant.services.conversation_service import ConversationService
 from assistant.services.llm_service import LLMService
 from assistant.services.memory_storage import MemoryStorage
+from assistant.services.tool_service import ToolService
+from assistant.services.tools.errors import (
+    UnsupportedToolError,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -74,13 +84,23 @@ def mock_context_assembly():
 
 
 @pytest.fixture
+def mock_tool_service():
+    """Create a mock ToolService."""
+    return AsyncMock(spec=ToolService)
+
+
+@pytest.fixture
 def conversation_service(
-    mock_llm_service, mock_memory_storage, mock_context_assembly
+    mock_llm_service,
+    mock_memory_storage,
+    mock_context_assembly,
+    mock_tool_service,
 ):
     """Create a ConversationService with mocked dependencies."""
     return ConversationService(
         llm_service=mock_llm_service,
         context_assembly=mock_context_assembly,
+        tool_service=mock_tool_service,
     )
 
 
@@ -1271,3 +1291,687 @@ async def test_add_message_to_conversation_empty_llm_choices(
 
     assert exc_info.value.status_code == 502
     assert 'did not return any choices' in exc_info.value.detail.lower()
+
+
+# Tests for tool loop functionality
+
+
+@pytest.fixture
+def mock_tool_result():
+    """Create a mock tool execution result."""
+    from datetime import datetime, timezone
+
+    return ToolExecutionResult(
+        tool_name='test_tool',
+        status=ToolExecutionStatus.SUCCESS,
+        tool_call={
+            'name': 'test_tool',
+            'arguments': {'query': 'test'},
+            'started_at': datetime.now(timezone.utc),
+            'finished_at': datetime.now(timezone.utc),
+            'status': ToolExecutionStatus.SUCCESS,
+        },
+        llm_context='Tool execution successful',
+    )
+
+
+@pytest.fixture
+def llm_response_with_tool_call():
+    """Create an LLM response with a tool call."""
+    tool_call = ChatCompletionMessageToolCall(
+        id='call_123',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='test_tool',
+            arguments='{"query": "test"}',
+        ),
+    )
+    return LLMCompletionResult(
+        content='I will search for that information.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=15,
+        total_tokens=25,
+        tool_calls=[tool_call],
+        finish_reason='tool_calls',
+    )
+
+
+@pytest.fixture
+def llm_response_with_multiple_tool_calls():
+    """Create an LLM response with multiple tool calls."""
+    tool_calls = [
+        ChatCompletionMessageToolCall(
+            id='call_1',
+            type='function',
+            function=ChatCompletionMessageToolCallFunction(
+                name='search_tool',
+                arguments='{"query": "python"}',
+            ),
+        ),
+        ChatCompletionMessageToolCall(
+            id='call_2',
+            type='function',
+            function=ChatCompletionMessageToolCallFunction(
+                name='fetch_tool',
+                arguments='{"url": "https://example.com"}',
+            ),
+        ),
+    ]
+    return LLMCompletionResult(
+        content='I will search and fetch information.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        tool_calls=tool_calls,
+        finish_reason='tool_calls',
+    )
+
+
+async def test_call_llm_chat_completion_single_tool_call(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    llm_response_with_tool_call,
+    mock_tool_result,
+):
+    """It executes a single tool call and returns final assistant content."""
+    # First call returns tool call, second call returns content
+    final_response = LLMCompletionResult(
+        content='Here is the search result.',
+        model='llama3.2',
+        prompt_tokens=20,
+        completion_tokens=25,
+        total_tokens=45,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_llm_service.complete_messages.side_effect = [
+        llm_response_with_tool_call,
+        final_response,
+    ]
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+    mock_tool_service.get_available_tools.return_value = []
+
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Search for python'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    # Verify final content is returned
+    assert result == 'Here is the search result.'
+
+    # Verify LLM was called twice (initial + follow-up)
+    assert mock_llm_service.complete_messages.call_count == 2
+
+    # Verify tool was executed
+    mock_tool_service.execute_tool.assert_called_once_with(
+        name='test_tool',
+        arguments={'query': 'test'},
+    )
+
+
+async def test_call_llm_chat_completion_multiple_tool_calls_same_round(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    llm_response_with_multiple_tool_calls,
+    mock_tool_result,
+):
+    """It executes multiple tool calls in the same round."""
+    final_response = LLMCompletionResult(
+        content='Here are the results from both tools.',
+        model='llama3.2',
+        prompt_tokens=30,
+        completion_tokens=35,
+        total_tokens=65,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_llm_service.complete_messages.side_effect = [
+        llm_response_with_multiple_tool_calls,
+        final_response,
+    ]
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+    mock_tool_service.get_available_tools.return_value = []
+
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Search and fetch'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    assert result == 'Here are the results from both tools.'
+
+    # Both tools should have been executed
+    assert mock_tool_service.execute_tool.call_count == 2
+
+
+async def test_call_llm_chat_completion_multiple_rounds(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    llm_response_with_tool_call,
+    mock_tool_result,
+):
+    """It handles multiple rounds of tool calling."""
+    # Create second tool call response
+    second_tool_response = LLMCompletionResult(
+        content='I will also search for related info.',
+        model='llama3.2',
+        prompt_tokens=30,
+        completion_tokens=15,
+        total_tokens=45,
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id='call_456',
+                type='function',
+                function=ChatCompletionMessageToolCallFunction(
+                    name='test_tool',
+                    arguments='{"query": "related"}',
+                ),
+            ),
+        ],
+        finish_reason='tool_calls',
+    )
+
+    final_response = LLMCompletionResult(
+        content='Here are all the results.',
+        model='llama3.2',
+        prompt_tokens=50,
+        completion_tokens=30,
+        total_tokens=80,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_llm_service.complete_messages.side_effect = [
+        llm_response_with_tool_call,
+        second_tool_response,
+        final_response,
+    ]
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+    mock_tool_service.get_available_tools.return_value = []
+
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Search for info'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    assert result == 'Here are all the results.'
+
+    # LLM called 3 times and tool executed 2 times
+    assert mock_llm_service.complete_messages.call_count == 3
+    assert mock_tool_service.execute_tool.call_count == 2
+
+
+async def test_call_llm_chat_completion_tool_execution_error(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    llm_response_with_tool_call,
+):
+    """It raises HTTPException when tool execution fails."""
+    mock_llm_service.complete_messages.return_value = (
+        llm_response_with_tool_call
+    )
+    mock_tool_service.get_available_tools.return_value = []
+    mock_tool_service.execute_tool.side_effect = UnsupportedToolError(
+        'test_tool'
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Search'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert 'unsupported tool' in str(exc_info.value.detail).lower()
+
+
+async def test_call_llm_chat_completion_max_rounds_exceeded(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+):
+    """It raises HTTPException when maximum tool rounds are exceeded."""
+    tool_call_response = LLMCompletionResult(
+        content='I will search.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=10,
+        total_tokens=20,
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id='call_123',
+                type='function',
+                function=ChatCompletionMessageToolCallFunction(
+                    name='test_tool',
+                    arguments='{"query": "test"}',
+                ),
+            ),
+        ],
+        finish_reason='tool_calls',
+    )
+
+    # Always return tool calls to trigger max rounds
+    mock_llm_service.complete_messages.return_value = tool_call_response
+    mock_tool_service.get_available_tools.return_value = []
+    from datetime import datetime, timezone
+
+    mock_tool_service.execute_tool.return_value = ToolExecutionResult(
+        tool_name='test_tool',
+        status=ToolExecutionStatus.SUCCESS,
+        tool_call={
+            'name': 'test_tool',
+            'arguments': {},
+            'started_at': datetime.now(timezone.utc),
+            'finished_at': datetime.now(timezone.utc),
+            'status': ToolExecutionStatus.SUCCESS,
+        },
+        llm_context='Result',
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Search'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert 'exceeded maximum tool rounds' in exc_info.value.detail.lower()
+
+
+async def test_call_llm_chat_completion_tool_messages_appended_correctly(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    llm_response_with_tool_call,
+    mock_tool_result,
+):
+    """It appends tool results correctly to message history."""
+    final_response = LLMCompletionResult(
+        content='Final answer.',
+        model='llama3.2',
+        prompt_tokens=30,
+        completion_tokens=15,
+        total_tokens=45,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_llm_service.complete_messages.side_effect = [
+        llm_response_with_tool_call,
+        final_response,
+    ]
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+    mock_tool_service.get_available_tools.return_value = []
+
+    await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Test'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    # Verify second LLM call includes tool result message
+    second_call_args = mock_llm_service.complete_messages.call_args_list[1]
+    messages = second_call_args.kwargs['messages']
+
+    # Should have system message + user message + assistant message with tool_calls + tool result message
+    assert len(messages) >= 4
+    # Last message should be tool result
+    tool_message = messages[-1]
+    assert tool_message['role'] == 'tool'
+    assert tool_message['tool_call_id'] == 'call_123'
+    assert tool_message['content'] == mock_tool_result.llm_context
+
+
+async def test_call_llm_chat_completion_with_json_tool_arguments(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    mock_tool_result,
+):
+    """It correctly parses JSON arguments from tool calls."""
+    # Tool call with complex JSON arguments
+    tool_call_with_json = ChatCompletionMessageToolCall(
+        id='call_json',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='complex_tool',
+            arguments='{"query": "test", "filters": {"type": "article", "limit": 10}, "sort": "date"}',
+        ),
+    )
+
+    tool_response = LLMCompletionResult(
+        content='I will execute the complex tool.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=12,
+        total_tokens=22,
+        tool_calls=[tool_call_with_json],
+        finish_reason='tool_calls',
+    )
+
+    final_response = LLMCompletionResult(
+        content='Here are the results.',
+        model='llama3.2',
+        prompt_tokens=30,
+        completion_tokens=10,
+        total_tokens=40,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_llm_service.complete_messages.side_effect = [
+        tool_response,
+        final_response,
+    ]
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+    mock_tool_service.get_available_tools.return_value = []
+
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Complex search'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    assert result == 'Here are the results.'
+
+    # Verify tool was called with parsed JSON arguments
+    mock_tool_service.execute_tool.assert_called_once_with(
+        name='complex_tool',
+        arguments={
+            'query': 'test',
+            'filters': {'type': 'article', 'limit': 10},
+            'sort': 'date',
+        },
+    )
+
+
+async def test_add_message_with_tool_call_flow(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+    async_session,
+    test_user_id,
+    mock_context_assembly,
+    mock_context_result,
+    mock_tool_result,
+):
+    """It handles complete message addition with tool calling."""
+    # Create a conversation
+    conversation = Conversation(
+        user_id=test_user_id,
+        title='Tool Calling Conversation',
+    )
+    async_session.add(conversation)
+    await async_session.flush()
+
+    user_message = Message(
+        conversation_id=conversation.id,
+        role='user',
+        content='Initial message',
+        sequence_number=1,
+    )
+    async_session.add(user_message)
+
+    assistant_message = Message(
+        conversation_id=conversation.id,
+        role='assistant',
+        content='Initial response',
+        sequence_number=2,
+    )
+    async_session.add(assistant_message)
+    await async_session.commit()
+
+    # Set up mock responses for tool calling
+    tool_call_response = LLMCompletionResult(
+        content='I will search for that.',
+        model='llama3.2',
+        prompt_tokens=15,
+        completion_tokens=10,
+        total_tokens=25,
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id='call_abc',
+                type='function',
+                function=ChatCompletionMessageToolCallFunction(
+                    name='search_tool',
+                    arguments='{"q": "python"}',
+                ),
+            ),
+        ],
+        finish_reason='tool_calls',
+    )
+
+    final_response = LLMCompletionResult(
+        content='Python is a programming language.',
+        model='llama3.2',
+        prompt_tokens=30,
+        completion_tokens=20,
+        total_tokens=50,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_context_assembly.assemble_context.return_value = mock_context_result
+    mock_llm_service.complete_messages.side_effect = [
+        tool_call_response,
+        final_response,
+    ]
+    mock_tool_service.get_available_tools.return_value = []
+    mock_tool_service.execute_tool.return_value = mock_tool_result
+
+    # Add new message
+    payload = CreateMessageRequest(
+        content='What is Python?',
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    result = await conversation_service.add_message_to_conversation(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    )
+
+    # Verify final assistant response is from after tool execution
+    assert (
+        result.assistant_message.content == 'Python is a programming language.'
+    )
+
+    # Verify conversation was updated
+    stmt = (
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    db_result = await async_session.execute(stmt)
+    messages = list(db_result.scalars().all())
+
+    # Should have initial messages + new user message + final assistant response
+    assert len(messages) == 4
+    assert messages[2].content == 'What is Python?'
+    assert messages[3].content == 'Python is a programming language.'
+
+
+# Tests for tool argument validation
+
+
+async def test_call_llm_chat_completion_malformed_json_arguments(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+):
+    """It raises HTTPException when tool arguments are malformed JSON."""
+    # Tool call with invalid JSON
+    malformed_tool_call = ChatCompletionMessageToolCall(
+        id='call_bad',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='broken_tool',
+            arguments='{invalid json}',  # Not valid JSON
+        ),
+    )
+
+    tool_response = LLMCompletionResult(
+        content='I will execute the tool.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=12,
+        total_tokens=22,
+        tool_calls=[malformed_tool_call],
+        finish_reason='tool_calls',
+    )
+
+    mock_llm_service.complete_messages.return_value = tool_response
+    mock_tool_service.get_available_tools.return_value = []
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Test'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert 'invalid tool arguments json' in exc_info.value.detail.lower()
+
+
+async def test_call_llm_chat_completion_tool_arguments_array(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+):
+    """It raises HTTPException when tool arguments are JSON array instead of object."""
+    # Tool call with JSON array instead of object
+    array_tool_call = ChatCompletionMessageToolCall(
+        id='call_array',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='array_tool',
+            arguments='["arg1", "arg2"]',  # Valid JSON but not an object
+        ),
+    )
+
+    tool_response = LLMCompletionResult(
+        content='I will execute the tool.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=12,
+        total_tokens=22,
+        tool_calls=[array_tool_call],
+        finish_reason='tool_calls',
+    )
+
+    mock_llm_service.complete_messages.return_value = tool_response
+    mock_tool_service.get_available_tools.return_value = []
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Test'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert (
+        'tool arguments must be a json object' in exc_info.value.detail.lower()
+    )
+    assert 'list' in exc_info.value.detail.lower()
+
+
+async def test_call_llm_chat_completion_tool_arguments_string(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+):
+    """It raises HTTPException when tool arguments are JSON string instead of object."""
+    # Tool call with JSON string instead of object
+    string_tool_call = ChatCompletionMessageToolCall(
+        id='call_string',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='string_tool',
+            arguments='"just a string"',  # Valid JSON but not an object
+        ),
+    )
+
+    tool_response = LLMCompletionResult(
+        content='I will execute the tool.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=12,
+        total_tokens=22,
+        tool_calls=[string_tool_call],
+        finish_reason='tool_calls',
+    )
+
+    mock_llm_service.complete_messages.return_value = tool_response
+    mock_tool_service.get_available_tools.return_value = []
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Test'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert (
+        'tool arguments must be a json object' in exc_info.value.detail.lower()
+    )
+    assert 'str' in exc_info.value.detail.lower()
+
+
+async def test_call_llm_chat_completion_tool_arguments_number(
+    conversation_service,
+    mock_llm_service,
+    mock_tool_service,
+):
+    """It raises HTTPException when tool arguments are JSON number instead of object."""
+    # Tool call with JSON number instead of object
+    number_tool_call = ChatCompletionMessageToolCall(
+        id='call_number',
+        type='function',
+        function=ChatCompletionMessageToolCallFunction(
+            name='number_tool',
+            arguments='42',  # Valid JSON but not an object
+        ),
+    )
+
+    tool_response = LLMCompletionResult(
+        content='I will execute the tool.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=12,
+        total_tokens=22,
+        tool_calls=[number_tool_call],
+        finish_reason='tool_calls',
+    )
+
+    mock_llm_service.complete_messages.return_value = tool_response
+    mock_tool_service.get_available_tools.return_value = []
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service._call_llm_chat_completion(
+            messages=[{'role': 'user', 'content': 'Test'}],
+            temperature=0.7,
+            max_tokens=512,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert (
+        'tool arguments must be a json object' in exc_info.value.detail.lower()
+    )
+    assert 'int' in exc_info.value.detail.lower()

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -1,7 +1,7 @@
 """Tests for ConversationService."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 import uuid
 
 from fastapi import HTTPException
@@ -86,7 +86,9 @@ def mock_context_assembly():
 @pytest.fixture
 def mock_tool_service():
     """Create a mock ToolService."""
-    return AsyncMock(spec=ToolService)
+    mock_service = Mock(spec=ToolService)
+    mock_service.execute_tool = AsyncMock()
+    return mock_service
 
 
 @pytest.fixture

--- a/apps/assistant-backend/tests/services/test_tool_service.py
+++ b/apps/assistant-backend/tests/services/test_tool_service.py
@@ -1,0 +1,45 @@
+"""Tests for the shared tool service and first concrete tool."""
+
+import pytest
+
+from assistant.models.tool import TimePayload, ToolExecutionStatus
+from assistant.services.tool_service import ToolService
+from assistant.services.tools.current_time import CurrentTimeTool
+from assistant.services.tools.errors import UnsupportedToolError
+from assistant.services.tools.factory import ToolFactory
+
+
+def test_get_available_tools_returns_current_time_definition():
+    service = ToolService(factory=ToolFactory(tools=[CurrentTimeTool()]))
+
+    tools = service.get_available_tools()
+
+    assert len(tools) == 1
+    assert tools[0]['function']['name'] == 'get_current_time'
+
+
+@pytest.mark.asyncio
+async def test_execute_current_time_tool():
+    service = ToolService(factory=ToolFactory(tools=[CurrentTimeTool()]))
+
+    result = await service.execute_tool(
+        name='get_current_time',
+        arguments={},
+    )
+
+    assert result.tool_name == 'get_current_time'
+    assert result.status == ToolExecutionStatus.SUCCESS
+    assert result.payload is not None
+    assert isinstance(result.payload, TimePayload)
+    assert 'Current server time:' in result.llm_context
+
+
+@pytest.mark.asyncio
+async def test_execute_unknown_tool_raises():
+    service = ToolService(factory=ToolFactory(tools=[CurrentTimeTool()]))
+
+    with pytest.raises(UnsupportedToolError):
+        await service.execute_tool(
+            name='does_not_exist',
+            arguments={},
+        )

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -375,6 +375,17 @@ Chroma retrieval was deliberately excluded from the Step 3 shipped implementatio
 
 Create a small reusable tool layer that supports the first research path now and future tools, such as image generation, soon after.
 
+**Completed groundwork**
+
+The initial Step 4 foundation has already landed:
+
+- added a shared `ToolService` plus explicit `BaseTool` and `ToolFactory` seams
+- added typed tool execution models so `ConversationService` and future annotation work can share one normalized result contract
+- added a deterministic `get_current_time` validation tool to prove the tool path end to end without mixing in search/fetch complexity
+- updated `ConversationService` and `LLMService` to support a bounded model-native tool loop with shared tool definitions
+
+The remaining Step 4 work is the first real research path: `web_search` for discovery and `web_fetch` for grounded page reads.
+
 **Files**
 
 - add `apps/assistant-backend/src/assistant/services/tool_service.py`
@@ -560,6 +571,8 @@ Create a small reusable tool layer that supports the first research path now and
 [x] durable fact table exists
 [x] shared LLM completion helper exists
 [x] ContextAssemblyService exists
+[x] reusable backend tool layer exists
+[x] deterministic validation tool exists
 [ ] web_search + web_fetch tool path works
 [ ] AssistantAnnotationService exists
 [ ] terminal assistant failure rows persist on backend failure

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -6,7 +6,7 @@ Ship the first trustworthy-assistant upgrade on top of the existing chat app:
 
 - context compression
 - durable fact memory
-- one controlled tool, `web_search`
+- one controlled research tool path, `web_search` + `web_fetch`
 - message-level trust annotations in the chat UI
 
 This plan is the implementation spec for phase 1.
@@ -81,6 +81,13 @@ ContextAssemblyService
   ->
 shared LLM completion helper
   ->
+ToolService
+  ->  BaseTool
+  ->  ToolFactory
+  ->  web_search
+  ->  web_fetch
+  ->  future tools, for example image generation
+  ->
 assistant result + tool outputs
   ->
 AssistantAnnotationService
@@ -118,6 +125,10 @@ Suggested shape:
     {
       "name": "web_search",
       "label": "Web search"
+    },
+    {
+      "name": "web_fetch",
+      "label": "Web fetch"
     }
   ],
   "sources": [
@@ -224,8 +235,9 @@ They keep trust payloads useful instead of bloated.
 - `source.snippet`: max `240` chars
 - `memory.hits`: max `2`
 - `memory.saved`: max `1`
-- `tools_used`: max `2`, though phase 1 should only use `web_search`
+- `tools_used`: max `2`, with phase 1 limited to `web_search` + `web_fetch`
 - never persist raw full tool outputs in `annotations`
+- never treat raw search snippets as final evidence
 - never inject `annotations` back into model prompt assembly
 - prompt assembly uses:
   - recent turns only
@@ -309,7 +321,7 @@ They keep trust payloads useful instead of bloated.
 - Added typed seam models for shared completion results and service-level error classification
 - Refactored `LLMService` to own canonical request construction, transport, response validation, and first-choice extraction
 - Updated the chat router and `ConversationService` to use the shared seam instead of duplicating response parsing
-- Preserved `tool_calls` and `finish_reason` in the seam result so the upcoming `web_search` tool path can build on it cleanly
+- Preserved `tool_calls` and `finish_reason` in the seam result so the upcoming research tool path can build on it cleanly
 - Removed the deprecated public raw completion wrapper to keep one supported backend completion path
 - Expanded backend regression coverage around seam parsing, error mapping, and both existing callers
 
@@ -349,7 +361,7 @@ Bounded context assembly from canonical Postgres sources (summaries, facts, rece
 - Added `ContextAssemblyService` with a typed `ContextAssemblyResult` for prepared messages and debug metadata
 - Load latest conversation summary, active per-user durable facts, and capped recent-turn window from canonical Postgres tables
 - Enforced explicit prompt budgets: 4 recent turns with summary, 8 without; max 5 facts; text truncation at 200 chars/fact and 1000 chars/summary
-- Updated `ConversationService` to use `ContextAssemblyService` for both new and existing conversation replies  
+- Updated `ConversationService` to use `ContextAssemblyService` for both new and existing conversation replies
 - Added regression test preventing duplicate user messages in prompts
 - All code and tests reflect Postgres-only implementation; Chroma retrieval support deferred to Step 6+
 
@@ -357,28 +369,59 @@ Bounded context assembly from canonical Postgres sources (summaries, facts, rece
 
 Chroma retrieval was deliberately excluded from the Step 3 shipped implementation in favor of keeping the code simple and honest. Canonical Postgres summaries + facts + recent turns provide a solid foundation. Once Step 5 has written full summary and fact text to Postgres, Step 6 will add retrieval-backed ranking and context augmentation for candidates.
 
-### Step 4. Extract summary + facts via background job
+### Step 4. Add the first research tool path: `web_search` + `web_fetch`
+
+**Purpose**
+
+Create a small reusable tool layer that supports the first research path now and future tools, such as image generation, soon after.
 
 **Files**
 
-- add a thin backend service such as `apps/assistant-backend/src/assistant/services/web_search_service.py`
+- add `apps/assistant-backend/src/assistant/services/tool_service.py`
+- add `apps/assistant-backend/src/assistant/services/tools/base.py`
+- add `apps/assistant-backend/src/assistant/services/tools/factory.py`
+- add `apps/assistant-backend/src/assistant/services/tools/web_search.py`
+- add `apps/assistant-backend/src/assistant/services/tools/web_fetch.py`
 - update [apps/assistant-backend/src/assistant/settings.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/settings.py)
 - update [apps/assistant-backend/src/assistant/services/conversation_service.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/services/conversation_service.py)
+- update [apps/assistant-backend/src/assistant/services/context_assembly.py](/Users/stuartlangley/src/sjlangley/family-assistant/apps/assistant-backend/src/assistant/services/context_assembly.py) only as needed for bounded retrieval support
 
 **Work**
 
-- support one configured `web_search` backend
-- keep it behind a tiny internal wrapper, not a provider registry
-- let the model choose the tool natively
-- convert tool result into:
-  - final answer context
-  - persisted trust annotations
+- support one configured research tool path composed of:
+  - `web_search` to discover candidate sources
+  - `web_fetch` to read selected pages
+- add a small `BaseTool` contract that owns:
+  - tool definition exposed to the model
+  - tool execution
+  - enabled/disabled checks
+- add a `ToolFactory` that is the explicit allowlist and lookup point for supported tools
+- add a `ToolService` that:
+  - exposes the available tool definitions to the model
+  - dispatches tool calls by name
+  - returns normalized tool execution results
+- keep the implementation explicit and hardcoded, not a dynamic plugin system or provider registry
+- let the model use the search/fetch path natively through the shared tool layer
+- require final answers to ground source annotations in fetched page content, not raw search snippets alone
+- keep retrieval support, if used, separate from external web research:
+  - retrieval is bounded prompt context
+  - fetched web pages are external evidence
+- convert fetched results into compact structured source inputs for the annotation step
+- keep the tool layer small enough that future tools, such as image generation, can be added without reshaping `ConversationService`
 
 **Acceptance criteria**
 
-- only `web_search` is exposed in phase 1
-- tool results can produce trust-row and evidence-panel content
-- tool failure can still end in a terminal assistant failure row
+- the assistant can search for candidate sources and fetch the selected pages before answering
+- search snippets alone are not treated as sufficient evidence for trust annotations
+- one explicit tool allowlist exists through `ToolFactory`
+- one shared tool execution/result path exists through `ToolService`
+- fetched page content can produce:
+  - source title
+  - source URL
+  - compact supporting snippet
+  - rationale for why the source matters
+- failures in search or fetch can still produce a clear terminal assistant failure row
+- the implementation remains limited to one controlled research path in phase 1
 
 ### Step 5. Add `AssistantAnnotationService`
 
@@ -517,7 +560,7 @@ Chroma retrieval was deliberately excluded from the Step 3 shipped implementatio
 [x] durable fact table exists
 [x] shared LLM completion helper exists
 [x] ContextAssemblyService exists
-[ ] web_search tool path works
+[ ] web_search + web_fetch tool path works
 [ ] AssistantAnnotationService exists
 [ ] terminal assistant failure rows persist on backend failure
 [ ] BackgroundTasks extraction writes summaries/facts
@@ -561,7 +604,7 @@ Phase 1 is ready when all of these are true:
 - evidence panel content comes from stored annotations, not regenerated guesses
 - summary and durable fact memory are canonical in Postgres
 - Chroma is only retrieval support
-- `web_search` is the only tool in play
+- `web_search` + `web_fetch` are the only research tools in play
 - tests cover success, failure, reload, and budget edges
 - the UI matches [DESIGN.md](/Users/stuartlangley/src/sjlangley/family-assistant/DESIGN.md)
 


### PR DESCRIPTION
## Summary
- add the initial backend tool layer with `BaseTool`, `ToolFactory`, `ToolService`, and typed tool models
- add a deterministic `get_current_time` tool to validate end-to-end tool execution without search/fetch complexity
- wire a bounded tool-calling loop into `ConversationService` and pass tool definitions through the shared LLM seam
- add tool-service and conversation-service coverage for tool execution, multi-round loops, and failure handling
- update the implementation plan to describe the new tool-layer structure and the `web_search` + `web_fetch` research path

## Testing
- Not run (not requested in this pass)