### PR TITLE
fix(backend): switch local tool runtime to Ollama

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ ALLOWED_HOSTED_DOMAINS=
 SESSION_SECRET_KEY=your-secure-random-session-secret-key-here
 
 # LLM Backend Configuration
-# Docker Compose defaults to the bundled Ollama service
-LLM_BASE_URL=http://ollama:11434
+# Default for local non-Docker backend runs; Docker Compose should override
+# this for the backend container to use the bundled Ollama service.
+LLM_BASE_URL=http://localhost:11434
 LLM_TIMEOUT_SECONDS=120
 LLM_MODEL=qwen2.5:7b
 

--- a/.env.example
+++ b/.env.example
@@ -42,10 +42,10 @@ ALLOWED_HOSTED_DOMAINS=
 SESSION_SECRET_KEY=your-secure-random-session-secret-key-here
 
 # LLM Backend Configuration
-# URL to your llama.cpp server (typically running on host machine)
-LLM_BASE_URL=http://host.docker.internal:8000
+# Docker Compose defaults to the bundled Ollama service
+LLM_BASE_URL=http://ollama:11434
 LLM_TIMEOUT_SECONDS=120
-LLM_MODEL=llama-3.1-8b-instruct
+LLM_MODEL=qwen2.5:7b
 
 
 # =============================================================================
@@ -74,9 +74,9 @@ VITE_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 #    - Keep this secret and never commit it to version control
 #
 # 3. LLM Server:
-#    - Must be running separately on your host machine
+#    - Docker Compose now includes an Ollama service by default
+#    - For local non-Docker development, point LLM_BASE_URL at your host server
 #    - See apps/llm-server/README.md for setup instructions
-#    - Use host.docker.internal to access host services from Docker
 #
 # 4. Database:
 #    - PostgreSQL data persists in a Docker volume

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -10,12 +10,14 @@ The Docker Compose setup includes:
 - **Backend** - FastAPI application serving the API (`assistant-backend`)
 - **Frontend** - React application serving the UI (`assistant-ui`)
 
-**Note:** The LLM server runs separately on your host machine. See `apps/llm-server/README.md` for setup instructions.
+**Note:** Docker Compose now includes an `ollama` service by default. You can still point
+the backend at another host-run OpenAI-compatible server if you want; see
+`apps/llm-server/README.md` for setup details.
 
 ## Prerequisites
 
 - **Docker** and **Docker Compose** installed
-- **LLM Server** running on your host machine (see `apps/llm-server/README.md`)
+- **Local LLM runtime** available either through the bundled Ollama service or a host-run server (see `apps/llm-server/README.md`)
 - **Google OAuth credentials** (see setup instructions below)
 
 ## Quick Start
@@ -53,18 +55,18 @@ openssl rand -hex 32
    - `http://localhost:3000`
 5. Copy the Client ID to both `GOOGLE_OAUTH_CLIENT_ID` and `VITE_GOOGLE_CLIENT_ID` in `.env`
 
-### 4. Start the LLM Server
+### 4. Start the LLM Runtime
 
-The backend needs an LLM server to be running. Follow the instructions in `apps/llm-server/README.md` to:
+Docker Compose now includes an `ollama` service by default. After the stack is up,
+pull the default model once:
 
 ```bash
-# Example: Start llama.cpp server (adjust based on your setup)
-# See apps/llm-server/README.md for detailed instructions
-./llama-server \
-  --model path/to/model.gguf \
-  --port 8000 \
-  --chat-template llama3
+docker compose up -d ollama
+docker compose exec ollama ollama pull qwen2.5:7b
 ```
+
+If you want to use a different local server instead, follow the instructions in
+`apps/llm-server/README.md` and update `LLM_BASE_URL` / `LLM_MODEL` accordingly.
 
 ### 5. Build and Start Services
 
@@ -82,6 +84,7 @@ The services will be available at:
 - **Backend API**: http://localhost:8080
 - **Backend Health**: http://localhost:8080/health
 - **PostgreSQL**: localhost:5432
+- **Ollama API**: http://localhost:11434
 
 ### 6. View Logs
 
@@ -197,10 +200,10 @@ npm run dev  # Runs on port 5173
 
 ### Backend can't connect to LLM server
 
-- Ensure LLM server is running on your host machine
-- Check `LLM_BASE_URL` uses `host.docker.internal` for Docker setup
-- Verify the port matches your LLM server port (default: 8000)
-- Test: `curl http://localhost:8000/v1/models`
+- Ensure the Ollama service is running: `docker compose ps ollama`
+- Pull the configured model: `docker compose exec ollama ollama pull qwen2.5:7b`
+- Check `LLM_BASE_URL` matches the runtime you want to use
+- Test: `curl http://localhost:11434/api/tags`
 
 ### Google OAuth errors
 
@@ -230,7 +233,7 @@ POSTGRES_PORT=5433
 Services communicate via a private Docker network (`family-assistant-network`). The backend connects to:
 
 - PostgreSQL at `postgres:5432` (internal network)
-- LLM server at `host.docker.internal:8000` (host machine)
+- Ollama at `ollama:11434` (internal network)
 
 ### Health Checks
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports **text chat with a local LLM**, **persistent conversation history**, an
 - **Conversation management**
   Persistent conversations stored in PostgreSQL — create new chats, resume old ones, and browse history.
 - **LLM chat**
-  Text chat powered by llama.cpp running locally (via Docker or on the host machine).
+  Text chat powered by a local OpenAI-compatible LLM runtime, with Docker Compose now defaulting to Ollama.
 - **Authentication & security**
   Google OAuth 2.0 with server-side session cookies. Per-user data isolation enforced at the API layer.
 
@@ -22,7 +22,7 @@ Supports **text chat with a local LLM**, **persistent conversation history**, an
 
 - **Backend:** Python 3.13+ / FastAPI
 - **Frontend:** TypeScript / React 18 / Vite
-- **LLM Runtime:** llama.cpp (llama-cpp-python server, OpenAI-compatible API)
+- **LLM Runtime:** Ollama by default in Docker Compose, or another local OpenAI-compatible server
 - **Database:** PostgreSQL 16 (SQLModel / SQLAlchemy async)
 - **Authentication:** Google OAuth 2.0 (server-side sessions)
 - **Linting & Formatting:** Ruff + Pyrefly (backend), ESLint + Prettier (frontend)
@@ -44,6 +44,9 @@ cp .env.example .env
 
 # 3. Start all services
 docker compose up --build
+
+# 4. Pull the default local model once
+docker compose exec ollama ollama pull qwen2.5:7b
 ```
 
 See [DOCKER.md](DOCKER.md) for detailed Docker setup instructions.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cp .env.example .env
 # Edit .env with your Google OAuth credentials and other settings
 
 # 3. Start all services
-docker compose up --build
+docker compose up -d --build
 
 # 4. Pull the default local model once
 docker compose exec ollama ollama pull qwen2.5:7b

--- a/apps/assistant-backend/README.md
+++ b/apps/assistant-backend/README.md
@@ -4,7 +4,7 @@ Backend service for the Family Assistant application.
 
 Provides authenticated REST APIs for user management, conversation history, and LLM chat
 completions. Uses Google OAuth 2.0 for authentication, PostgreSQL for persistent storage,
-and an external llama.cpp server for LLM inference.
+and an external OpenAI-compatible LLM server for inference.
 
 ---
 
@@ -13,7 +13,7 @@ and an external llama.cpp server for LLM inference.
 * **Google OAuth 2.0 authentication** — verifies Google ID tokens and manages server-side sessions
 * **Session management** — cookie-based sessions via Starlette `SessionMiddleware`
 * **User API** — retrieve the currently authenticated user
-* **LLM chat completions** — proxies chat requests to a local llama.cpp server
+* **LLM chat completions** — proxies chat requests to a local OpenAI-compatible LLM server
 * **Shared LLM completion seam** — one typed backend path now powers both the direct chat endpoint and conversation replies, with common response validation and error handling
 * **Bounded conversation context assembly** — existing conversation replies now use the latest saved summary, active per-user durable facts, and a capped recent-turn window instead of blindly resending the full transcript
 * **Initial tool layer** — `BaseTool`, `ToolFactory`, and `ToolService` now provide one explicit backend tool seam with typed execution results and shared allowlist-based dispatch
@@ -48,7 +48,7 @@ and an external llama.cpp server for LLM inference.
 
 * Python 3.13+
 * PostgreSQL 16 (or SQLite for tests via `DATABASE_URL=sqlite+aiosqlite:///:memory:`)
-* A running llama.cpp server (see `apps/llm-server/README.md`)
+* A running OpenAI-compatible LLM server such as Ollama (see `apps/llm-server/README.md`)
 
 Install dependencies:
 
@@ -64,8 +64,8 @@ Copy `.env.example` to `.env` and configure:
 |---|---|---|
 | `GOOGLE_OAUTH_CLIENT_ID` | Google OAuth 2.0 client ID | Yes |
 | `SESSION_SECRET_KEY` | Secret for signing session cookies | Yes |
-| `LLM_BASE_URL` | Base URL of the llama.cpp server | Yes |
-| `LLM_MODEL` | Model name to pass to the LLM API | No (default: `gpt-4`) |
+| `LLM_BASE_URL` | Base URL of the local OpenAI-compatible LLM server | Yes |
+| `LLM_MODEL` | Model name to pass to the LLM API | No (default in Docker Compose: `qwen2.5:7b`) |
 | `LLM_TIMEOUT_SECONDS` | Request timeout for LLM calls | No (default: `120`) |
 | `DATABASE_URL` | Full SQLAlchemy database URL | No (uses TCP params below) |
 | `DATABASE_HOST` | PostgreSQL host | No (default: `localhost`) |

--- a/apps/assistant-backend/src/assistant/models/llm.py
+++ b/apps/assistant-backend/src/assistant/models/llm.py
@@ -531,7 +531,7 @@ class HTTPValidationError(BaseModel):
 class ChatCompletionResponseChoice(BaseModel):
     index: int = Field(..., title='Index')
     message: ChatCompletionResponseMessage
-    logprobs: ChatCompletionLogprobs | None
+    logprobs: ChatCompletionLogprobs | None = None
     finish_reason: str | None = Field(..., title='Finish Reason')
 
 

--- a/apps/llm-server/README.md
+++ b/apps/llm-server/README.md
@@ -60,6 +60,20 @@ uvx hf download \
   --local-dir ./models
 ```
 
+```bash
+uvx hf download \
+  bartowski/Qwen2.5-7B-Instruct-GGUF \
+  Qwen2.5-7B-Instruct-Q4_K_M.gguf \
+  --local-dir ~/models
+```
+
+```bash
+uvx hf download \
+  bartowski/Qwen2.5-7B-Instruct-GGUF \
+  Qwen2.5-7B-Instruct-Q5_K_M.gguf \
+  --local-dir ~/models
+```
+
 **Option B: Using huggingface-cli**
 
 Use the hugging face UI.

--- a/apps/llm-server/README.md
+++ b/apps/llm-server/README.md
@@ -1,29 +1,30 @@
 # LLM Server
 
-Local inference server for running Large Language Models using llama.cpp. Provides
-an OpenAI-compatible API for chat completions.
+Local inference server setup for running Large Language Models behind an
+OpenAI-compatible API for chat completions.
 
 ## Overview
 
 This directory contains instructions for setting up a local LLM server that serves
-models with an OpenAI-compatible HTTP API. The assistant backend (`apps/assistant-backend`)
-communicates with this server via the `/v1/chat/completions` endpoint.
+models with an OpenAI-compatible HTTP API. The assistant backend
+(`apps/assistant-backend`) communicates with this server via the
+`/v1/chat/completions` endpoint.
 
 There are two ways to run the LLM server:
 
 1. **Docker Compose** (recommended) — the `docker-compose.yml` in the repository root
-   includes a `llama-cpp-python` service. Place your GGUF model at
-   `~/models/meta-llama-3.1-8b-instruct-q4_k_m.gguf` and run `docker compose up`.
-2. **Manually on the host** — follow the Quick Start below to install and run the server
-   directly. This is useful for GPU-accelerated inference or when running only part of the
-   stack in Docker.
+   includes an `ollama` service. Pull `qwen2.5:7b` into Ollama and run
+   `docker compose up`.
+2. **Manually on the host** — follow the Quick Start below to install and run a local
+   server directly. This is useful for GPU-accelerated inference or when running only
+   part of the stack in Docker.
 
 **Key Features:**
 
 - OpenAI-compatible API
-- Runs quantized models efficiently on consumer hardware
-- Supports llama.cpp GGUF format models
-- Configurable chat formats (llama-3, chatml, etc.)
+- Docker Compose defaults to Ollama with `qwen2.5:7b`
+- Ollama provides a clean local tool-calling response shape for the backend tool loop
+- llama.cpp remains available as a manual alternative when you want lower-level control
 
 ## Prerequisites
 
@@ -49,42 +50,30 @@ After installation, restart your terminal or run:
 source $HOME/.cargo/env
 ```
 
-### 2. Download a Model
+### 2. Run Ollama (recommended)
 
-**Option A: Using uvx (recommended)**
-
-```bash
-uvx hf download \
-  joshnader/Meta-Llama-3.1-8B-Instruct-Q4_K_M-GGUF \
-  meta-llama-3.1-8b-instruct-q4_k_m.gguf \
-  --local-dir ./models
-```
+Start the Ollama server:
 
 ```bash
-uvx hf download \
-  bartowski/Qwen2.5-7B-Instruct-GGUF \
-  Qwen2.5-7B-Instruct-Q4_K_M.gguf \
-  --local-dir ~/models
+ollama serve
 ```
+
+Then pull the default model:
 
 ```bash
-uvx hf download \
-  bartowski/Qwen2.5-7B-Instruct-GGUF \
-  Qwen2.5-7B-Instruct-Q5_K_M.gguf \
-  --local-dir ~/models
+ollama pull qwen2.5:7b
 ```
 
-**Option B: Using huggingface-cli**
+You can verify the local model list with:
 
-Use the hugging face UI.
+```bash
+ollama list
+```
 
-**Popular Model Options:**
+### 3. Optional: Run llama-cpp-python manually
 
-- `joshnader/Meta-Llama-3.1-8B-Instruct-Q4_K_M-GGUF` - Balanced performance
-- `bartowski/Meta-Llama-3.1-8B-Instruct-GGUF` - Multiple quantization options
-- `TheBloke/Mistral-7B-Instruct-v0.2-GGUF` - Efficient alternative
-
-### 3. Install llama-cpp-python Server
+If you want to keep experimenting with GGUF models and manual template control, you can
+still run `llama-cpp-python` directly.
 
 ```bash
 pip install llama-cpp-python[server]
@@ -114,8 +103,17 @@ python -m llama_cpp.server \
 
 The server will start and be available at `http://localhost:8000`
 
+### 5. Ollama API endpoint
+
+Ollama serves its OpenAI-compatible API at:
+
+```text
+http://localhost:11434/v1
+```
+
 **Important:** The assistant-backend expects the LLM server at the URL specified in
-`LLM_BASE_URL` environment variable (defaults to `http://host.docker.internal:8000`).
+`LLM_BASE_URL`. Because the backend appends `/v1/chat/completions` itself, set
+`LLM_BASE_URL` to the root server URL, for example `http://localhost:11434`.
 
 ## Configuration Options
 
@@ -157,16 +155,16 @@ Then configure your backend to use `http://localhost:8000` as the `LLM_BASE_URL`
 ### Health Check
 
 ```bash
-curl http://localhost:8000/health
+curl http://localhost:11434/api/tags
 ```
 
 ### Test Chat Completion
 
 ```bash
-curl http://localhost:8000/v1/chat/completions \
+curl http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "llama-3.1-8b",
+    "model": "qwen2.5:7b",
     "messages": [
       {"role": "user", "content": "Hello, who are you?"}
     ],
@@ -182,7 +180,7 @@ Expected response:
   "id": "chatcmpl-xxx",
   "object": "chat.completion",
   "created": 1234567890,
-  "model": "llama-3.1-8b",
+  "model": "qwen2.5:7b",
   "choices": [
     {
       "index": 0,
@@ -206,15 +204,15 @@ Expected response:
 Update the backend configuration in `apps/assistant-backend/.env` (or the root `.env` for Docker Compose):
 
 ```env
-LLM_BASE_URL=http://localhost:8000
-LLM_MODEL=llama-3.1-8b-instruct
+LLM_BASE_URL=http://localhost:11434
+LLM_MODEL=qwen2.5:7b
 LLM_TIMEOUT_SECONDS=120
 ```
 
-When running via Docker Compose the backend connects to the `llama-cpp-python` service
-automatically; the `LLM_BASE_URL` is set to `http://llama-cpp-python:8000` inside the
-container network. For local development outside Docker, point `LLM_BASE_URL` at the
-host address where the server is running.
+When running via Docker Compose the backend connects to the `ollama` service
+automatically; the `LLM_BASE_URL` is set to `http://ollama:11434` inside the container
+network. For local development outside Docker, point `LLM_BASE_URL` at the host address
+where the server is running.
 
 The backend will automatically connect to the LLM server and use it for chat completions
 via the `/v1/chat/completions` endpoint.
@@ -256,7 +254,7 @@ via the `/v1/chat/completions` endpoint.
 **Issue**: Backend can't reach LLM server
 
 - **Solution**:
-  - Verify the server is running: `curl http://localhost:8000/health`
+  - Verify the server is running: `curl http://localhost:11434/api/tags`
   - Check `LLM_BASE_URL` in backend `.env` matches the server host/port
   - Ensure firewall allows connections on the specified port
   - For remote servers, verify SSH port forwarding is active
@@ -265,13 +263,13 @@ via the `/v1/chat/completions` endpoint.
 
 | Model | Size | RAM Required | Best For |
 |-------|------|--------------|----------|
-| Meta-Llama-3.1-8B-Instruct (Q4_K_M) | ~5GB | 8GB+ | General purpose, good quality/speed balance |
-| Meta-Llama-3.1-8B-Instruct (Q8_0) | ~8GB | 12GB+ | Higher quality, slower inference |
-| Mistral-7B-Instruct (Q4_K_M) | ~4GB | 6GB+ | Efficient, faster inference |
-| Phi-3-mini (Q4_K_M) | ~2.5GB | 4GB+ | Low resource environments |
+| `qwen2.5:7b` via Ollama | ~4.7GB download | 8GB+ | Default local development path with working tool calls |
+| Qwen2.5-7B-Instruct (Q4_K_M GGUF) | ~4.7GB | 8GB+ | Manual llama.cpp experiments |
+| Qwen2.5-7B-Instruct (Q5_K_M GGUF) | ~5.4GB | 10GB+ | Better quality manual llama.cpp experiments |
 
 ## Resources
 
+- [Ollama Documentation](https://ollama.com)
 - [llama.cpp Documentation](https://github.com/ggerganov/llama.cpp)
 - [llama-cpp-python Server](https://github.com/abetlen/llama-cpp-python)
 - [Hugging Face GGUF Models](https://huggingface.co/models?library=gguf)
@@ -281,6 +279,6 @@ via the `/v1/chat/completions` endpoint.
 
 This setup uses third-party tools and models. Refer to their respective licenses:
 
+- Ollama: MIT License
 - llama.cpp: MIT License
 - Model licenses vary by provider
-

--- a/apps/llm-server/README.md
+++ b/apps/llm-server/README.md
@@ -13,8 +13,10 @@ models with an OpenAI-compatible HTTP API. The assistant backend
 There are two ways to run the LLM server:
 
 1. **Docker Compose** (recommended) — the `docker-compose.yml` in the repository root
-   includes an `ollama` service. Pull `qwen2.5:7b` into Ollama and run
-   `docker compose up`.
+   includes an `ollama` service. Start the container first with
+   `docker compose up -d ollama`, pull `qwen2.5:7b` with
+   `docker compose exec ollama ollama pull qwen2.5:7b`, and then run
+   `docker compose up` for the full stack.
 2. **Manually on the host** — follow the Quick Start below to install and run a local
    server directly. This is useful for GPU-accelerated inference or when running only
    part of the stack in Docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,23 +22,16 @@ services:
     networks:
       - family-assistant-network
 
-  llama-cpp-python:
-    image: 3x3cut0r/llama-cpp-python:latest
-    container_name: llama-cpp-python
-    cap_add:
-      - SYS_RESOURCE
-    environment:
-        MODEL_DOWNLOAD: "False"
-        MODEL_REPO: "local"
-        MODEL: "meta-llama-3.1-8b-instruct-q4_k_m.gguf"
-        MODEL_ALIAS: "meta-llama-3.1-8b-instruct"
-        CHAT_FORMAT: "llama-3"
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
     volumes:
-      - ~/models/meta-llama-3.1-8b-instruct-q4_k_m.gguf:/model/meta-llama-3.1-8b-instruct-q4_k_m.gguf
+      - ollama_data:/root/.ollama
     ports:
-      - 8000:8000/tcp
+      - "11434:11434"
     networks:
       - family-assistant-network
+    restart: unless-stopped
 
   chroma:
     image: chromadb/chroma:1.5.5
@@ -74,9 +67,9 @@ services:
       SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:?SESSION_SECRET_KEY must be set}
 
       # LLM backend configuration
-      LLM_BASE_URL: http://llama-cpp-python:8000
+      LLM_BASE_URL: http://ollama:11434
       LLM_TIMEOUT_SECONDS: ${LLM_TIMEOUT_SECONDS:-120}
-      LLM_MODEL: ${LLM_MODEL:-llama-3.1-8b-instruct}
+      LLM_MODEL: ${LLM_MODEL:-qwen2.5:7b}
 
       # Database configuration (for future use)
       DATABASE_URL: postgresql+asyncpg://assistant:${POSTGRES_PASSWORD:-changeme_in_production}@postgres:5432/family_assistant
@@ -127,6 +120,8 @@ volumes:
   postgres_data:
     driver: local
   chroma_data:
+    driver: local
+  ollama_data:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:?SESSION_SECRET_KEY must be set}
 
       # LLM backend configuration
-      LLM_BASE_URL: http://ollama:11434
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://ollama:11434}
       LLM_TIMEOUT_SECONDS: ${LLM_TIMEOUT_SECONDS:-120}
       LLM_MODEL: ${LLM_MODEL:-qwen2.5:7b}
 


### PR DESCRIPTION
## Summary
- switch the Docker Compose local LLM runtime from `llama-cpp-python` to Ollama with `qwen2.5:7b`
- relax the generated chat completion response model so providers that omit `choices[].logprobs` still validate cleanly
- sync README, Docker, env, backend, and LLM server docs to the new Ollama-first local setup

## Testing
- not run automated tests in this pass
- manually verified Ollama `/v1/chat/completions` returns structured `tool_calls` for the current-time tool flow
