### PR TITLE
feat(backend): AssistantAnnotationService for structured conversation annotations

### DIFF
--- a/apps/assistant-backend/src/assistant/services/__init__.py
+++ b/apps/assistant-backend/src/assistant/services/__init__.py
@@ -1,5 +1,8 @@
 from functools import lru_cache
 
+from assistant.services.assistant_annotations import (
+    AssistantAnnotationService,
+)
 from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.conversation_service import ConversationService
 from assistant.services.llm_service import LLMService
@@ -54,4 +57,5 @@ def get_conversation_service() -> ConversationService:
         llm_service=get_llm_service(),
         context_assembly=get_context_assembly_service(),
         tool_service=get_tool_service(),
+        annotation_service=AssistantAnnotationService(),
     )

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -121,8 +121,9 @@ class AssistantAnnotationService:
 
             payload: WebFetchPayload = tool_result.payload
 
-            snippet = payload.excerpt or self._truncate_text(
-                payload.content, self.MAX_SOURCES_SNIPPET_LENGTH
+            snippet_source = payload.excerpt or payload.content
+            snippet = self._truncate_text(
+                snippet_source, self.MAX_SOURCES_SNIPPET_LENGTH
             )
 
             source = SourceAnnotation(

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -82,7 +82,7 @@ class AssistantAnnotationService:
         failure_annotation = FailureAnnotation(
             stage=stage,
             retryable=self._is_error_retryable(error),
-            detail=self._format_error_detail(error),
+            detail=self.format_error_detail(error),
         )
 
         # Preserve tool metadata and sources even on failure
@@ -238,11 +238,11 @@ class AssistantAnnotationService:
 
         return error.kind in retryable_kinds
 
-    def _format_error_detail(
+    def format_error_detail(
         self,
         error: LLMCompletionError | None,
     ) -> str | None:
-        """Format error message for user display."""
+        """Format error message for user display and storage."""
         if error is None:
             return None
 

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -34,21 +34,25 @@ class AssistantAnnotationService:
         self,
         *,
         executed_tools: list[ToolExecutionResult],
+        fact_ids: list | None = None,
     ) -> AssistantAnnotations:
         """Build success annotations from tool execution results.
 
         Only extracts sources from web_fetch payloads (actual fetched content),
         never from raw web_search snippets alone.
 
+        Includes memory facts that were injected into the prompt context.
+
         Enforces all budget limits.
         """
         sources = self._extract_sources_from_fetches(executed_tools)
         tools = self._extract_tool_annotations(executed_tools)
+        memory_hits = self._extract_memory_hits(fact_ids or [])
 
         return AssistantAnnotations(
             sources=sources,
             tools=tools,
-            memory_hits=[],
+            memory_hits=memory_hits,
             memory_saved=[],
             failure=None,
         )
@@ -57,12 +61,15 @@ class AssistantAnnotationService:
         self,
         *,
         error: LLMCompletionError | None = None,
+        executed_tools: list[ToolExecutionResult] | None = None,
     ) -> AssistantAnnotations:
         """Build failure annotations for terminal assistant error rows.
 
-        Maps LLM error kinds to appropriate failure stages.
+        Maps error origins to appropriate failure stages and preserves
+        tool/source metadata from work accomplished before the failure.
         """
-        stage = self._determine_failure_stage(error)
+        executed = executed_tools or []
+        stage = self._determine_failure_stage(error, executed_tools=executed)
 
         failure_annotation = FailureAnnotation(
             stage=stage,
@@ -70,9 +77,13 @@ class AssistantAnnotationService:
             detail=self._format_error_detail(error),
         )
 
+        # Preserve tool metadata and sources even on failure
+        sources = self._extract_sources_from_fetches(executed)
+        tools = self._extract_tool_annotations(executed)
+
         return AssistantAnnotations(
-            sources=[],
-            tools=[],
+            sources=sources,
+            tools=tools,
             memory_hits=[],
             memory_saved=[],
             failure=failure_annotation,
@@ -161,6 +172,22 @@ class AssistantAnnotationService:
 
         return tools
 
+    def _extract_memory_hits(
+        self,
+        fact_ids: list,
+    ) -> list:
+        """Extract memory facts injected into the prompt.
+
+        Budget: max 2 facts. Only includes facts that were actually
+        used in context assembly.
+        """
+        # For now, we track fact_ids but don't store full content
+        # (full fact retrieval deferred to Step 6+ UI work)
+        # Return count-limited list of fact IDs
+        hit_ids = fact_ids[:self.MAX_MEMORY_HITS]
+        # Placeholder: future steps will hydrate with full fact metadata
+        return hit_ids
+
     # ─────────────────────────────────────────────────────────────────────
     # Private helpers for failure annotations
     # ─────────────────────────────────────────────────────────────────────
@@ -168,14 +195,22 @@ class AssistantAnnotationService:
     def _determine_failure_stage(
         self,
         error: LLMCompletionError | None,
+        executed_tools: list[ToolExecutionResult] | None = None,
     ) -> FailureAnnotationStage:
-        """Map LLM error kind to failure stage."""
+        """Map error origin to appropriate failure stage.
+
+        If tools were executed before the error, it was a tool-phase failure.
+        Otherwise, it was an LLM-phase failure.
+        """
         if error is None:
             return FailureAnnotationStage.UNKNOWN
 
-        # All known error kinds from LLM service are LLM-stage errors
-        # (timeout, unreachable, backend_error, invalid_response)
-        # Tool-stage errors would be caught and mapped differently
+        # If tools ran before the failure, it likely failed during tool phase
+        if executed_tools:
+            return FailureAnnotationStage.TOOL
+
+        # No tools executed = LLM phase error
+        # (timeout, unreachable, backend_error from LLM service)
         return FailureAnnotationStage.LLM
 
     def _is_error_retryable(

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -1,0 +1,235 @@
+"""Service for building persisted trust annotations on assistant responses."""
+
+from assistant.models.annotations import (
+    AssistantAnnotations,
+    FailureAnnotation,
+    FailureAnnotationStage,
+    SourceAnnotation,
+    ToolAnnotation,
+    ToolAnnotationStatus,
+)
+from assistant.models.llm import LLMCompletionError
+from assistant.models.tool import (
+    ToolExecutionResult,
+    ToolExecutionStatus,
+    WebFetchPayload,
+)
+
+
+class AssistantAnnotationService:
+    """Builds compact, budget-conscious trust annotations for assistant responses.
+
+    Handles both successful responses (with tool outputs and sources) and
+    terminal failures (with failure metadata).
+    """
+
+    # Budget limits - enforced at persistence time
+    MAX_SOURCES = 3
+    MAX_SOURCES_SNIPPET_LENGTH = 240
+    MAX_TOOLS = 2
+    MAX_MEMORY_HITS = 2
+    MAX_MEMORY_SAVED = 1
+
+    def build_success_annotations(
+        self,
+        *,
+        executed_tools: list[ToolExecutionResult],
+    ) -> AssistantAnnotations:
+        """Build success annotations from tool execution results.
+
+        Only extracts sources from web_fetch payloads (actual fetched content),
+        never from raw web_search snippets alone.
+
+        Enforces all budget limits.
+        """
+        sources = self._extract_sources_from_fetches(executed_tools)
+        tools = self._extract_tool_annotations(executed_tools)
+
+        return AssistantAnnotations(
+            sources=sources,
+            tools=tools,
+            memory_hits=[],
+            memory_saved=[],
+            failure=None,
+        )
+
+    def build_failure_annotations(
+        self,
+        *,
+        error: LLMCompletionError | None = None,
+    ) -> AssistantAnnotations:
+        """Build failure annotations for terminal assistant error rows.
+
+        Maps LLM error kinds to appropriate failure stages.
+        """
+        stage = self._determine_failure_stage(error)
+
+        failure_annotation = FailureAnnotation(
+            stage=stage,
+            retryable=self._is_error_retryable(error),
+            detail=self._format_error_detail(error),
+        )
+
+        return AssistantAnnotations(
+            sources=[],
+            tools=[],
+            memory_hits=[],
+            memory_saved=[],
+            failure=failure_annotation,
+        )
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Private helpers for success annotations
+    # ─────────────────────────────────────────────────────────────────────
+
+    def _extract_sources_from_fetches(
+        self,
+        executed_tools: list[ToolExecutionResult],
+    ) -> list[SourceAnnotation]:
+        """Extract sources only from web_fetch results (not raw search snippets).
+
+        Budget: max 3 sources, snippets capped at 240 chars.
+        """
+        sources = []
+
+        for tool_result in executed_tools:
+            if tool_result.status != ToolExecutionStatus.SUCCESS:
+                continue
+
+            if tool_result.tool_name != 'web_fetch':
+                continue
+
+            if not isinstance(tool_result.payload, WebFetchPayload):
+                continue
+
+            payload: WebFetchPayload = tool_result.payload
+
+            snippet = payload.excerpt or self._truncate_text(
+                payload.content, self.MAX_SOURCES_SNIPPET_LENGTH
+            )
+
+            source = SourceAnnotation(
+                title=payload.title or 'Untitled',
+                url=payload.url,
+                snippet=snippet,
+                rationale='Referenced in the assistant response',
+            )
+            sources.append(source)
+
+            if len(sources) >= self.MAX_SOURCES:
+                break
+
+        return sources
+
+    def _extract_tool_annotations(
+        self,
+        executed_tools: list[ToolExecutionResult],
+    ) -> list[ToolAnnotation]:
+        """Extract tool annotations from executed tools.
+
+        Budget: max 2 tools. Only includes tools that actually ran (not just
+        those that were attempted but failed at parsing level).
+        """
+        tools = []
+        seen_tool_names = set()
+
+        for tool_result in executed_tools:
+            tool_name = tool_result.tool_name
+
+            # Skip duplicates (use first occurrence)
+            if tool_name in seen_tool_names:
+                continue
+
+            # Only include tools with valid payloads (not failed parses)
+            if tool_result.status == ToolExecutionStatus.ERROR:
+                continue
+
+            status_map = {
+                ToolExecutionStatus.SUCCESS: ToolAnnotationStatus.COMPLETED,
+                ToolExecutionStatus.ERROR: ToolAnnotationStatus.FAILED,
+            }
+
+            tool_annotation = ToolAnnotation(
+                name=tool_name,
+                status=status_map[tool_result.status],
+            )
+            tools.append(tool_annotation)
+            seen_tool_names.add(tool_name)
+
+            if len(tools) >= self.MAX_TOOLS:
+                break
+
+        return tools
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Private helpers for failure annotations
+    # ─────────────────────────────────────────────────────────────────────
+
+    def _determine_failure_stage(
+        self,
+        error: LLMCompletionError | None,
+    ) -> FailureAnnotationStage:
+        """Map LLM error kind to failure stage."""
+        if error is None:
+            return FailureAnnotationStage.UNKNOWN
+
+        # All known error kinds from LLM service are LLM-stage errors
+        # (timeout, unreachable, backend_error, invalid_response)
+        # Tool-stage errors would be caught and mapped differently
+        return FailureAnnotationStage.LLM
+
+    def _is_error_retryable(
+        self,
+        error: LLMCompletionError | None,
+    ) -> bool:
+        """Determine if a failure is transient and retryable."""
+        if error is None:
+            return False
+
+        retryable_kinds = {
+            'timeout',
+            'unreachable',
+            'backend_error',
+        }
+
+        return error.kind in retryable_kinds
+
+    def _format_error_detail(
+        self,
+        error: LLMCompletionError | None,
+    ) -> str | None:
+        """Format error message for user display."""
+        if error is None:
+            return None
+
+        # Return the error message if available
+        if hasattr(error, 'message') and error.message:
+            return error.message
+
+        kind_labels = {
+            'timeout': 'Request timed out',
+            'unreachable': 'Unable to reach LLM service',
+            'backend_error': 'LLM service error',
+            'invalid_response': 'Invalid LLM response',
+        }
+
+        return kind_labels.get(error.kind, 'Unknown error')
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Utility helpers
+    # ─────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _truncate_text(text: str, max_length: int) -> str:
+        """Truncate text to max length, preserving word boundaries."""
+        if len(text) <= max_length:
+            return text
+
+        truncated = text[:max_length].rstrip()
+        if truncated and truncated[-1] not in '.!?':
+            # Try to end at word boundary
+            last_space = truncated.rfind(' ')
+            if last_space > max_length * 0.7:
+                truncated = truncated[:last_space]
+
+        return truncated + '...'

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -1,5 +1,7 @@
 """Service for building persisted trust annotations on assistant responses."""
 
+import uuid
+
 from assistant.models.annotations import (
     AssistantAnnotations,
     FailureAnnotation,
@@ -35,7 +37,7 @@ class AssistantAnnotationService:
         self,
         *,
         executed_tools: list[ToolExecutionResult],
-        fact_ids: list | None = None,
+        fact_ids: list[uuid.UUID] | None = None,
     ) -> AssistantAnnotations:
         """Build success annotations from tool execution results.
 
@@ -176,7 +178,7 @@ class AssistantAnnotationService:
 
     def _extract_memory_hits(
         self,
-        fact_ids: list,
+        fact_ids: list[uuid.UUID],
     ) -> list[MemoryHitAnnotation]:
         """Extract memory facts injected into the prompt.
 

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -4,6 +4,7 @@ from assistant.models.annotations import (
     AssistantAnnotations,
     FailureAnnotation,
     FailureAnnotationStage,
+    MemoryHitAnnotation,
     SourceAnnotation,
     ToolAnnotation,
     ToolAnnotationStatus,
@@ -175,7 +176,7 @@ class AssistantAnnotationService:
     def _extract_memory_hits(
         self,
         fact_ids: list,
-    ) -> list:
+    ) -> list[MemoryHitAnnotation]:
         """Extract memory facts injected into the prompt.
 
         Budget: max 2 facts. Only includes facts that were actually
@@ -183,7 +184,7 @@ class AssistantAnnotationService:
         """
         # Return count-limited list of fact IDs wrapped in dicts for Pydantic validation
         return [
-            {"label": "Memory Fact", "summary": f"Fact ID: {fid}"}
+            {'label': 'Memory Fact', 'summary': f'Fact ID: {fid}'}
             for fid in fact_ids[: self.MAX_MEMORY_HITS]
         ]
 

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -184,7 +184,7 @@ class AssistantAnnotationService:
         """
         # Return count-limited list of fact IDs wrapped in dicts for Pydantic validation
         return [
-            {'label': 'Memory Fact', 'summary': f'Fact ID: {fid}'}
+            MemoryHitAnnotation(label='Memory Fact', summary=f'Fact ID: {fid}')
             for fid in fact_ids[: self.MAX_MEMORY_HITS]
         ]
 

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -184,7 +184,7 @@ class AssistantAnnotationService:
         # For now, we track fact_ids but don't store full content
         # (full fact retrieval deferred to Step 6+ UI work)
         # Return count-limited list of fact IDs
-        hit_ids = fact_ids[:self.MAX_MEMORY_HITS]
+        hit_ids = fact_ids[: self.MAX_MEMORY_HITS]
         # Placeholder: future steps will hydrate with full fact metadata
         return hit_ids
 

--- a/apps/assistant-backend/src/assistant/services/assistant_annotations.py
+++ b/apps/assistant-backend/src/assistant/services/assistant_annotations.py
@@ -62,6 +62,7 @@ class AssistantAnnotationService:
         *,
         error: LLMCompletionError | None = None,
         executed_tools: list[ToolExecutionResult] | None = None,
+        attempted_tool_execution: bool = False,
     ) -> AssistantAnnotations:
         """Build failure annotations for terminal assistant error rows.
 
@@ -69,7 +70,11 @@ class AssistantAnnotationService:
         tool/source metadata from work accomplished before the failure.
         """
         executed = executed_tools or []
-        stage = self._determine_failure_stage(error, executed_tools=executed)
+        stage = self._determine_failure_stage(
+            error,
+            executed_tools=executed,
+            attempted_tool_execution=attempted_tool_execution,
+        )
 
         failure_annotation = FailureAnnotation(
             stage=stage,
@@ -138,11 +143,15 @@ class AssistantAnnotationService:
     ) -> list[ToolAnnotation]:
         """Extract tool annotations from executed tools.
 
-        Budget: max 2 tools. Only includes tools that actually ran (not just
-        those that were attempted but failed at parsing level).
+        Budget: max 2 tools. Includes both successful and failed tools
+        for transparency and debugging.
         """
         tools = []
         seen_tool_names = set()
+        status_map = {
+            ToolExecutionStatus.SUCCESS: ToolAnnotationStatus.COMPLETED,
+            ToolExecutionStatus.ERROR: ToolAnnotationStatus.FAILED,
+        }
 
         for tool_result in executed_tools:
             tool_name = tool_result.tool_name
@@ -150,15 +159,6 @@ class AssistantAnnotationService:
             # Skip duplicates (use first occurrence)
             if tool_name in seen_tool_names:
                 continue
-
-            # Only include tools with valid payloads (not failed parses)
-            if tool_result.status == ToolExecutionStatus.ERROR:
-                continue
-
-            status_map = {
-                ToolExecutionStatus.SUCCESS: ToolAnnotationStatus.COMPLETED,
-                ToolExecutionStatus.ERROR: ToolAnnotationStatus.FAILED,
-            }
 
             tool_annotation = ToolAnnotation(
                 name=tool_name,
@@ -181,12 +181,11 @@ class AssistantAnnotationService:
         Budget: max 2 facts. Only includes facts that were actually
         used in context assembly.
         """
-        # For now, we track fact_ids but don't store full content
-        # (full fact retrieval deferred to Step 6+ UI work)
-        # Return count-limited list of fact IDs
-        hit_ids = fact_ids[: self.MAX_MEMORY_HITS]
-        # Placeholder: future steps will hydrate with full fact metadata
-        return hit_ids
+        # Return count-limited list of fact IDs wrapped in dicts for Pydantic validation
+        return [
+            {"label": "Memory Fact", "summary": f"Fact ID: {fid}"}
+            for fid in fact_ids[: self.MAX_MEMORY_HITS]
+        ]
 
     # ─────────────────────────────────────────────────────────────────────
     # Private helpers for failure annotations
@@ -196,17 +195,23 @@ class AssistantAnnotationService:
         self,
         error: LLMCompletionError | None,
         executed_tools: list[ToolExecutionResult] | None = None,
+        attempted_tool_execution: bool = False,
     ) -> FailureAnnotationStage:
         """Map error origin to appropriate failure stage.
 
-        If tools were executed before the error, it was a tool-phase failure.
-        Otherwise, it was an LLM-phase failure.
+        Checks both whether tools were successfully executed and whether
+        the tool loop was attempted (which catches early parsing/execution failures).
         """
         if error is None:
             return FailureAnnotationStage.UNKNOWN
 
-        # If tools ran before the failure, it likely failed during tool phase
+        # If tools ran before the failure, it was a tool-phase failure
         if executed_tools:
+            return FailureAnnotationStage.TOOL
+
+        # If tool execution was attempted but failed early (parsing or first execution),
+        # it's still a tool-phase failure
+        if attempted_tool_execution:
             return FailureAnnotationStage.TOOL
 
         # No tools executed = LLM phase error

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -46,6 +46,7 @@ class _LLMLoopResult:
     content: str
     executed_tools: list[ToolExecutionResult]
     error: LLMCompletionError | None = None
+    attempted_tool_execution: bool = False  # True if tool loop was entered
 
 
 def conversation_title_from_first_message(content: str) -> str:
@@ -168,6 +169,7 @@ class ConversationService:
             annotations_obj = self.annotation_service.build_failure_annotations(
                 error=loop_result.error,
                 executed_tools=loop_result.executed_tools,
+                attempted_tool_execution=loop_result.attempted_tool_execution,
             )
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service._format_error_detail(
@@ -281,6 +283,7 @@ class ConversationService:
             annotations_obj = self.annotation_service.build_failure_annotations(
                 error=loop_result.error,
                 executed_tools=loop_result.executed_tools,
+                attempted_tool_execution=loop_result.attempted_tool_execution,
             )
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service._format_error_detail(
@@ -445,6 +448,7 @@ class ConversationService:
                             content='',
                             executed_tools=executed_tools,
                             error=error,
+                            attempted_tool_execution=True,
                         )
 
                     try:
@@ -463,6 +467,7 @@ class ConversationService:
                             content='',
                             executed_tools=executed_tools,
                             error=error,
+                            attempted_tool_execution=True,
                         )
 
                     llm_messages.append(

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -32,6 +32,8 @@ from assistant.services.assistant_annotations import (
 from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.llm_service import LLMService
 from assistant.services.tool_service import ToolService
+from assistant.services.tools.errors import UnsupportedToolError
+from assistant.services.tools.factory import DisabledToolError
 from assistant.settings import settings
 
 
@@ -457,8 +459,20 @@ class ConversationService:
                             arguments=parsed_arguments,
                         )
                         executed_tools.append(tool_result)
+                    except (UnsupportedToolError, DisabledToolError) as exc:
+                        # Tool config error - deterministic, non-retryable
+                        error = LLMCompletionError(
+                            kind=LLMCompletionErrorKind.invalid_response,
+                            message=f'Tool error: {str(exc)}',
+                        )
+                        return _LLMLoopResult(
+                            content='',
+                            executed_tools=executed_tools,
+                            error=error,
+                            attempted_tool_execution=True,
+                        )
                     except Exception as exc:
-                        # Tool execution error - return as terminal failure
+                        # Other tool execution error - return as terminal failure
                         error = LLMCompletionError(
                             kind=LLMCompletionErrorKind.backend_error,
                             message=f'Error executing tool {tool_call.function.name}: {str(exc)}',

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -174,7 +174,7 @@ class ConversationService:
                 attempted_tool_execution=loop_result.attempted_tool_execution,
             )
             annotations_dict = annotations_obj.model_dump()
-            error_text = self.annotation_service._format_error_detail(
+            error_text = self.annotation_service.format_error_detail(
                 loop_result.error
             )
         else:
@@ -288,7 +288,7 @@ class ConversationService:
                 attempted_tool_execution=loop_result.attempted_tool_execution,
             )
             annotations_dict = annotations_obj.model_dump()
-            error_text = self.annotation_service._format_error_detail(
+            error_text = self.annotation_service.format_error_detail(
                 loop_result.error
             )
         else:

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import json
 from typing import cast
 import uuid
@@ -20,13 +21,31 @@ from assistant.models.conversation_sql import Conversation, Message
 from assistant.models.llm import (
     ChatCompletionRequestSystemMessage,
     LLMCompletionError,
+    LLMCompletionErrorKind,
     ToolChoice,
 )
+from assistant.models.tool import ToolExecutionResult
 from assistant.routers.web_utils import llm_completion_error_to_http_exception
+from assistant.services.assistant_annotations import (
+    AssistantAnnotationService,
+)
 from assistant.services.context_assembly import ContextAssemblyService
 from assistant.services.llm_service import LLMService
 from assistant.services.tool_service import ToolService
 from assistant.settings import settings
+
+
+@dataclass
+class _LLMLoopResult:
+    """Internal result from the LLM tool loop.
+
+    Wraps the final assistant response along with tool execution history
+    for annotation building and error tracking.
+    """
+
+    content: str
+    executed_tools: list[ToolExecutionResult]
+    error: LLMCompletionError | None = None
 
 
 def conversation_title_from_first_message(content: str) -> str:
@@ -40,10 +59,14 @@ class ConversationService:
         llm_service: LLMService,
         context_assembly: ContextAssemblyService,
         tool_service: ToolService,
+        annotation_service: AssistantAnnotationService | None = None,
     ) -> None:
         self.llm_service = llm_service
         self.context_assembly = context_assembly
         self.tool_service = tool_service
+        self.annotation_service = (
+            annotation_service or AssistantAnnotationService()
+        )
 
     async def list_conversations(
         self,
@@ -132,18 +155,38 @@ class ConversationService:
         )
 
         # Make LLM call outside of transaction
-        assistant_content = await self._call_llm_chat_completion(
+        loop_result = await self._call_llm_chat_completion(
             messages=context_result.messages,
             temperature=payload.temperature,
             max_tokens=payload.max_tokens,
         )
 
+        # Build annotations or failure metadata
+        annotations_dict = None
+        error_text = None
+        if loop_result.error:
+            annotations_obj = self.annotation_service.build_failure_annotations(
+                error=loop_result.error
+            )
+            annotations_dict = annotations_obj.model_dump()
+            error_text = self.annotation_service._format_error_detail(
+                loop_result.error
+            )
+        else:
+            annotations_obj = self.annotation_service.build_success_annotations(
+                executed_tools=loop_result.executed_tools,
+            )
+            annotations_dict = annotations_obj.model_dump()
+
         # Transaction 2: Create assistant message and update conversation
         assistant_message = Message(
             conversation_id=conversation_id,
             role='assistant',
-            content=assistant_content,
+            content=loop_result.content
+            or ('Unable to generate a response. Please try again.'),
             sequence_number=2,
+            error=error_text,
+            annotations=annotations_dict,
         )
         session.add(assistant_message)
 
@@ -159,6 +202,10 @@ class ConversationService:
         await session.refresh(conversation)
         await session.refresh(user_message)
         await session.refresh(assistant_message)
+
+        # If there was a terminal error, raise HTTP exception after persisting
+        if loop_result.error:
+            raise llm_completion_error_to_http_exception(loop_result.error)
 
         return ConversationWithMessagesResponse(
             conversation=self._conversation_summary(conversation),
@@ -219,18 +266,38 @@ class ConversationService:
         )
 
         # Make LLM call outside of transaction
-        assistant_content = await self._call_llm_chat_completion(
+        loop_result = await self._call_llm_chat_completion(
             messages=context_result.messages,
             temperature=payload.temperature,
             max_tokens=payload.max_tokens,
         )
 
+        # Build annotations or failure metadata
+        annotations_dict = None
+        error_text = None
+        if loop_result.error:
+            annotations_obj = self.annotation_service.build_failure_annotations(
+                error=loop_result.error
+            )
+            annotations_dict = annotations_obj.model_dump()
+            error_text = self.annotation_service._format_error_detail(
+                loop_result.error
+            )
+        else:
+            annotations_obj = self.annotation_service.build_success_annotations(
+                executed_tools=loop_result.executed_tools,
+            )
+            annotations_dict = annotations_obj.model_dump()
+
         # Transaction 2: Create assistant message and update conversation
         assistant_message = Message(
             conversation_id=conversation_id,
             role='assistant',
-            content=assistant_content,
+            content=loop_result.content
+            or ('Unable to generate a response. Please try again.'),
             sequence_number=next_seq + 1,
+            error=error_text,
+            annotations=annotations_dict,
         )
         session.add(assistant_message)
 
@@ -245,6 +312,10 @@ class ConversationService:
         await session.refresh(conversation)
         await session.refresh(user_message)
         await session.refresh(assistant_message)
+
+        # If there was a terminal error, raise HTTP exception after persisting
+        if loop_result.error:
+            raise llm_completion_error_to_http_exception(loop_result.error)
 
         return ConversationWithMessagesResponse(
             conversation=self._conversation_summary(conversation),
@@ -297,10 +368,12 @@ class ConversationService:
         messages: list[dict],
         temperature: float,
         max_tokens: int | None,
-    ) -> str:
-        """Call LLM completion and return assistant content.
+    ) -> _LLMLoopResult:
+        """Call LLM completion and execute tools in a bounded loop.
 
-        Prepares system prompt and delegates to the shared LLM completion seam.
+        Returns a structured result with final content, executed tools,
+        and any errors encountered. Does not raise HTTP exceptions for
+        LLM/tool failures - those are handled at the persistence layer.
         """
         system_message = ChatCompletionRequestSystemMessage(
             role='system', content=SYSTEM_PROMPT
@@ -308,6 +381,8 @@ class ConversationService:
         llm_messages = [system_message.model_dump()] + messages
         available_tools = self.tool_service.get_available_tools()
         tools = available_tools if available_tools else None
+
+        executed_tools: list[ToolExecutionResult] = []
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
             try:
@@ -326,9 +401,16 @@ class ConversationService:
                 result = await self.llm_service.complete_messages(
                     **completion_kwargs
                 )
-                if not result.tool_calls:
-                    return result.content
 
+                # No tool calls - return final response
+                if not result.tool_calls:
+                    return _LLMLoopResult(
+                        content=result.content,
+                        executed_tools=executed_tools,
+                        error=None,
+                    )
+
+                # Tool calls requested - add assistant response and execute
                 llm_messages.append(
                     {
                         'role': 'assistant',
@@ -349,29 +431,35 @@ class ConversationService:
                                 f'Tool arguments must be a JSON object, '
                                 f'got {type(parsed_arguments).__name__}'
                             )
-                    except json.JSONDecodeError as exc:
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail=(
-                                f'Invalid tool arguments JSON: '
-                                f'{tool_call.function.name}'
-                            ),
-                        ) from exc
-                    except ValueError as exc:
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail=str(exc),
-                        ) from exc
+                    except (json.JSONDecodeError, ValueError) as exc:
+                        # Tool parsing error - return as terminal failure
+                        error = LLMCompletionError(
+                            kind=LLMCompletionErrorKind.invalid_response,
+                            message=f'Unable to parse tool arguments for {tool_call.function.name}: {str(exc)}',
+                        )
+                        return _LLMLoopResult(
+                            content='',
+                            executed_tools=executed_tools,
+                            error=error,
+                        )
+
                     try:
                         tool_result = await self.tool_service.execute_tool(
                             name=tool_call.function.name,
                             arguments=parsed_arguments,
                         )
+                        executed_tools.append(tool_result)
                     except Exception as exc:
-                        raise HTTPException(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail=f'Error executing tool {tool_call.function.name}: {str(exc)}',
-                        ) from exc
+                        # Tool execution error - return as terminal failure
+                        error = LLMCompletionError(
+                            kind=LLMCompletionErrorKind.backend_error,
+                            message=f'Error executing tool {tool_call.function.name}: {str(exc)}',
+                        )
+                        return _LLMLoopResult(
+                            content='',
+                            executed_tools=executed_tools,
+                            error=error,
+                        )
 
                     llm_messages.append(
                         {
@@ -382,11 +470,22 @@ class ConversationService:
                     )
 
             except LLMCompletionError as exc:
-                raise llm_completion_error_to_http_exception(exc) from exc
+                # LLM service error - return as terminal failure
+                return _LLMLoopResult(
+                    content='',
+                    executed_tools=executed_tools,
+                    error=exc,
+                )
 
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f'Assistant exceeded maximum tool rounds ({MAXIMUM_TOOL_ROUNDS})',
+        # Exceeded tool rounds - return as terminal failure
+        error = LLMCompletionError(
+            kind=LLMCompletionErrorKind.backend_error,
+            message=f'Assistant exceeded maximum tool rounds ({MAXIMUM_TOOL_ROUNDS})',
+        )
+        return _LLMLoopResult(
+            content='',
+            executed_tools=executed_tools,
+            error=error,
         )
 
     @staticmethod

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -166,7 +166,8 @@ class ConversationService:
         error_text = None
         if loop_result.error:
             annotations_obj = self.annotation_service.build_failure_annotations(
-                error=loop_result.error
+                error=loop_result.error,
+                executed_tools=loop_result.executed_tools,
             )
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service._format_error_detail(
@@ -175,6 +176,7 @@ class ConversationService:
         else:
             annotations_obj = self.annotation_service.build_success_annotations(
                 executed_tools=loop_result.executed_tools,
+                fact_ids=context_result.fact_ids,
             )
             annotations_dict = annotations_obj.model_dump()
 
@@ -277,7 +279,8 @@ class ConversationService:
         error_text = None
         if loop_result.error:
             annotations_obj = self.annotation_service.build_failure_annotations(
-                error=loop_result.error
+                error=loop_result.error,
+                executed_tools=loop_result.executed_tools,
             )
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service._format_error_detail(
@@ -286,6 +289,7 @@ class ConversationService:
         else:
             annotations_obj = self.annotation_service.build_success_annotations(
                 executed_tools=loop_result.executed_tools,
+                fact_ids=context_result.fact_ids,
             )
             annotations_dict = annotations_obj.model_dump()
 

--- a/apps/assistant-backend/tests/services/test_assistant_annotations.py
+++ b/apps/assistant-backend/tests/services/test_assistant_annotations.py
@@ -10,6 +10,7 @@ from assistant.models.annotations import (
 )
 from assistant.models.llm import (
     LLMCompletionError,
+    LLMCompletionErrorKind,
 )
 from assistant.models.tool import (
     ToolCallRecord,
@@ -252,7 +253,7 @@ class TestFailureAnnotations:
     def test_build_failure_annotations_llm_timeout(self, annotation_service):
         """Map LLM timeout to failure annotation."""
         error = LLMCompletionError(
-            kind='timeout',
+            kind=LLMCompletionErrorKind.timeout,
             message='Request timed out',
         )
 
@@ -268,7 +269,7 @@ class TestFailureAnnotations:
     ):
         """Map LLM unreachable to retryable failure annotation."""
         error = LLMCompletionError(
-            kind='unreachable',
+            kind=LLMCompletionErrorKind.unreachable,
             message='Unable to reach LLM service',
         )
 
@@ -282,7 +283,7 @@ class TestFailureAnnotations:
     ):
         """Map LLM backend error to retryable failure annotation."""
         error = LLMCompletionError(
-            kind='backend_error',
+            kind=LLMCompletionErrorKind.backend_error,
             message='Backend error',
         )
 
@@ -296,7 +297,7 @@ class TestFailureAnnotations:
     ):
         """Map invalid response to non-retryable failure annotation."""
         error = LLMCompletionError(
-            kind='invalid_response',
+            kind=LLMCompletionErrorKind.invalid_response,
             message='Invalid response from LLM',
         )
 
@@ -319,7 +320,7 @@ class TestFailureAnnotations:
     ):
         """Failure annotations should not include sources or tools."""
         error = LLMCompletionError(
-            kind='timeout',
+            kind=LLMCompletionErrorKind.timeout,
             message='Timeout',
         )
 

--- a/apps/assistant-backend/tests/services/test_assistant_annotations.py
+++ b/apps/assistant-backend/tests/services/test_assistant_annotations.py
@@ -1,0 +1,357 @@
+"""Tests for AssistantAnnotationService."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from assistant.models.annotations import (
+    FailureAnnotationStage,
+    ToolAnnotationStatus,
+)
+from assistant.models.llm import (
+    LLMCompletionError,
+)
+from assistant.models.tool import (
+    ToolCallRecord,
+    ToolExecutionResult,
+    ToolExecutionStatus,
+    WebFetchPayload,
+    WebSearchPayload,
+    WebSearchResultPayload,
+)
+from assistant.services.assistant_annotations import (
+    AssistantAnnotationService,
+)
+
+
+@pytest.fixture
+def annotation_service():
+    """Create an AssistantAnnotationService for testing."""
+    return AssistantAnnotationService()
+
+
+class TestSuccessAnnotations:
+    """Test success annotation building."""
+
+    def test_build_success_annotations_with_web_fetch_sources(
+        self, annotation_service
+    ):
+        """Extract sources only from web_fetch results, not search snippets."""
+        # Web search - should NOT produce sources
+        web_search_result = ToolExecutionResult(
+            tool_name='web_search',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name='web_search',
+                arguments={'query': 'test'},
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            payload=WebSearchPayload(
+                kind='web_search',
+                results=[
+                    WebSearchResultPayload(
+                        title='Result 1',
+                        url='https://example.com/1',
+                        snippet='Search snippet 1',
+                    )
+                ],
+            ),
+        )
+
+        # Web fetch - should produce sources
+        web_fetch_result = ToolExecutionResult(
+            tool_name='web_fetch',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name='web_fetch',
+                arguments={'url': 'https://example.com/page'},
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            payload=WebFetchPayload(
+                kind='web_fetch',
+                url='https://example.com/page',
+                title='Example Page',
+                content='This is the full page content with lots of information.',
+                excerpt='This is the full page content with lots of information.',
+            ),
+        )
+
+        annotations = annotation_service.build_success_annotations(
+            executed_tools=[web_search_result, web_fetch_result]
+        )
+
+        # Should have 1 source from fetch, 0 from search
+        assert len(annotations.sources) == 1
+        assert annotations.sources[0].title == 'Example Page'
+        assert annotations.sources[0].url == 'https://example.com/page'
+        assert (
+            annotations.sources[0].snippet
+            == 'This is the full page content with lots of information.'
+        )
+
+    def test_build_success_annotations_truncates_snippets(
+        self, annotation_service
+    ):
+        """Truncate source snippets to max 240 chars."""
+        long_content = 'x' * 500
+        web_fetch_result = ToolExecutionResult(
+            tool_name='web_fetch',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name='web_fetch',
+                arguments={'url': 'https://example.com'},
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            payload=WebFetchPayload(
+                kind='web_fetch',
+                url='https://example.com',
+                title='Page',
+                content=long_content,
+                excerpt=None,
+            ),
+        )
+
+        annotations = annotation_service.build_success_annotations(
+            executed_tools=[web_fetch_result]
+        )
+
+        assert len(annotations.sources) == 1
+        # Truncated text should be max 240 + "..." (may be fewer due to word boundary)
+        assert len(annotations.sources[0].snippet) <= 243
+        assert annotations.sources[0].snippet.endswith('...')
+
+    def test_build_success_annotations_enforces_source_budget(
+        self, annotation_service
+    ):
+        """Enforce max 3 sources budget."""
+        fetches = []
+        for i in range(5):
+            result = ToolExecutionResult(
+                tool_name='web_fetch',
+                status=ToolExecutionStatus.SUCCESS,
+                tool_call=ToolCallRecord(
+                    name='web_fetch',
+                    arguments={'url': f'https://example.com/{i}'},
+                    started_at=datetime.now(timezone.utc),
+                    finished_at=datetime.now(timezone.utc),
+                    status=ToolExecutionStatus.SUCCESS,
+                ),
+                payload=WebFetchPayload(
+                    kind='web_fetch',
+                    url=f'https://example.com/{i}',
+                    title=f'Page {i}',
+                    content=f'Content {i}',
+                    excerpt=f'Excerpt {i}',
+                ),
+            )
+            fetches.append(result)
+
+        annotations = annotation_service.build_success_annotations(
+            executed_tools=fetches
+        )
+
+        assert len(annotations.sources) == 3  # Max 3
+
+    def test_build_success_annotations_includes_tool_usage(
+        self, annotation_service
+    ):
+        """Include tool annotations for tools that ran."""
+        search_result = ToolExecutionResult(
+            tool_name='web_search',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name='web_search',
+                arguments={'query': 'test'},
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            payload=WebSearchPayload(
+                kind='web_search',
+                results=[],
+            ),
+        )
+
+        fetch_result = ToolExecutionResult(
+            tool_name='web_fetch',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call=ToolCallRecord(
+                name='web_fetch',
+                arguments={'url': 'https://example.com'},
+                started_at=datetime.now(timezone.utc),
+                finished_at=datetime.now(timezone.utc),
+                status=ToolExecutionStatus.SUCCESS,
+            ),
+            payload=WebFetchPayload(
+                kind='web_fetch',
+                url='https://example.com',
+                title='Page',
+                content='Content',
+            ),
+        )
+
+        annotations = annotation_service.build_success_annotations(
+            executed_tools=[search_result, fetch_result]
+        )
+
+        assert len(annotations.tools) == 2
+        assert annotations.tools[0].name == 'web_search'
+        assert annotations.tools[0].status == ToolAnnotationStatus.COMPLETED
+        assert annotations.tools[1].name == 'web_fetch'
+        assert annotations.tools[1].status == ToolAnnotationStatus.COMPLETED
+
+    def test_build_success_annotations_enforces_tool_budget(
+        self, annotation_service
+    ):
+        """Enforce max 2 tools budget."""
+        tools = []
+        for _i, tool_name in enumerate(
+            ['web_search', 'web_fetch', 'web_search']
+        ):
+            if tool_name == 'web_search':
+                payload = WebSearchPayload(kind='web_search', results=[])
+            else:
+                payload = WebFetchPayload(
+                    kind='web_fetch',
+                    url='https://example.com',
+                    title='Page',
+                    content='Content',
+                )
+
+            result = ToolExecutionResult(
+                tool_name=tool_name,
+                status=ToolExecutionStatus.SUCCESS,
+                tool_call=ToolCallRecord(
+                    name=tool_name,
+                    arguments={},
+                    started_at=datetime.now(timezone.utc),
+                    finished_at=datetime.now(timezone.utc),
+                    status=ToolExecutionStatus.SUCCESS,
+                ),
+                payload=payload,
+            )
+            tools.append(result)
+
+        annotations = annotation_service.build_success_annotations(
+            executed_tools=tools
+        )
+
+        # Should have max 2 tools, no duplicates
+        assert len(annotations.tools) <= 2
+
+
+class TestFailureAnnotations:
+    """Test failure annotation building."""
+
+    def test_build_failure_annotations_llm_timeout(self, annotation_service):
+        """Map LLM timeout to failure annotation."""
+        error = LLMCompletionError(
+            kind='timeout',
+            message='Request timed out',
+        )
+
+        annotations = annotation_service.build_failure_annotations(error=error)
+
+        assert annotations.failure is not None
+        assert annotations.failure.stage == FailureAnnotationStage.LLM
+        assert annotations.failure.retryable is True
+        assert 'timed out' in annotations.failure.detail.lower()
+
+    def test_build_failure_annotations_llm_unreachable(
+        self, annotation_service
+    ):
+        """Map LLM unreachable to retryable failure annotation."""
+        error = LLMCompletionError(
+            kind='unreachable',
+            message='Unable to reach LLM service',
+        )
+
+        annotations = annotation_service.build_failure_annotations(error=error)
+
+        assert annotations.failure.stage == FailureAnnotationStage.LLM
+        assert annotations.failure.retryable is True
+
+    def test_build_failure_annotations_llm_backend_error(
+        self, annotation_service
+    ):
+        """Map LLM backend error to retryable failure annotation."""
+        error = LLMCompletionError(
+            kind='backend_error',
+            message='Backend error',
+        )
+
+        annotations = annotation_service.build_failure_annotations(error=error)
+
+        assert annotations.failure.stage == FailureAnnotationStage.LLM
+        assert annotations.failure.retryable is True
+
+    def test_build_failure_annotations_invalid_response_not_retryable(
+        self, annotation_service
+    ):
+        """Map invalid response to non-retryable failure annotation."""
+        error = LLMCompletionError(
+            kind='invalid_response',
+            message='Invalid response from LLM',
+        )
+
+        annotations = annotation_service.build_failure_annotations(error=error)
+
+        assert annotations.failure.stage == FailureAnnotationStage.LLM
+        assert annotations.failure.retryable is False
+
+    def test_build_failure_annotations_no_error_is_unknown(
+        self, annotation_service
+    ):
+        """Unknown stage when no error provided."""
+        annotations = annotation_service.build_failure_annotations(error=None)
+
+        assert annotations.failure.stage == FailureAnnotationStage.UNKNOWN
+        assert annotations.failure.retryable is False
+
+    def test_build_failure_annotations_clears_sources_and_tools(
+        self, annotation_service
+    ):
+        """Failure annotations should not include sources or tools."""
+        error = LLMCompletionError(
+            kind='timeout',
+            message='Timeout',
+        )
+
+        annotations = annotation_service.build_failure_annotations(error=error)
+
+        assert len(annotations.sources) == 0
+        assert len(annotations.tools) == 0
+        assert len(annotations.memory_hits) == 0
+        assert len(annotations.memory_saved) == 0
+        assert annotations.failure is not None
+
+
+class TestTextTruncation:
+    """Test text truncation utility."""
+
+    def test_truncate_text_short_text_unchanged(self, annotation_service):
+        """Short text should not be truncated."""
+        short_text = 'This is short.'
+        truncated = annotation_service._truncate_text(short_text, 100)
+        assert truncated == short_text
+
+    def test_truncate_text_long_text_with_ellipsis(self, annotation_service):
+        """Long text should be truncated with ellipsis."""
+        long_text = 'A' * 300
+        truncated = annotation_service._truncate_text(long_text, 100)
+        assert len(truncated) <= 103  # 100 + "..."
+        assert truncated.endswith('...')
+
+    def test_truncate_text_preserves_word_boundaries(self, annotation_service):
+        """Truncation should try to preserve word boundaries."""
+        text = 'The quick brown fox jumps over the lazy dogs and cats and birds'
+        truncated = annotation_service._truncate_text(text, 40)
+        # Should end at reasonable word boundary, not mid-word
+        assert len(truncated) <= 42  # 40 + "..."
+        assert '...' in truncated

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -2125,7 +2125,7 @@ async def test_create_conversation_with_message_llm_failure_persists_error_row(
     stmt = (
         select(Message)
         .where(Message.role == 'assistant')
-        .where(Message.conversation_id is not None)
+        .where(Message.conversation_id.is_not(None))
     )
     result = await async_session.execute(stmt)
     messages = list(result.scalars().all())

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -12,6 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
+from assistant.models.annotations import (
+    AssistantAnnotations,
+    FailureAnnotationStage,
+)
 from assistant.models.conversation import (
     ConversationWithMessagesResponse,
     CreateConversationWithMessageRequest,
@@ -454,8 +458,11 @@ async def test_create_conversation_with_message_empty_assistant_content(
         payload=valid_request,
     )
 
-    # Should handle None content by converting to empty string
-    assert result.assistant_message.content == ''
+    # Should handle empty content by replacing with placeholder
+    assert (
+        result.assistant_message.content
+        == 'Unable to generate a response. Please try again.'
+    )
 
 
 # Tests for list_conversations
@@ -1405,7 +1412,8 @@ async def test_call_llm_chat_completion_single_tool_call(
     )
 
     # Verify final content is returned
-    assert result == 'Here is the search result.'
+    assert result.content == 'Here is the search result.'
+    assert result.error is None
 
     # Verify LLM was called twice (initial + follow-up)
     assert mock_llm_service.complete_messages.call_count == 2
@@ -1448,7 +1456,8 @@ async def test_call_llm_chat_completion_multiple_tool_calls_same_round(
         max_tokens=512,
     )
 
-    assert result == 'Here are the results from both tools.'
+    assert result.content == 'Here are the results from both tools.'
+    assert result.error is None
 
     # Both tools should have been executed
     assert mock_tool_service.execute_tool.call_count == 2
@@ -1506,7 +1515,8 @@ async def test_call_llm_chat_completion_multiple_rounds(
         max_tokens=512,
     )
 
-    assert result == 'Here are all the results.'
+    assert result.content == 'Here are all the results.'
+    assert result.error is None
 
     # LLM called 3 times and tool executed 2 times
     assert mock_llm_service.complete_messages.call_count == 3
@@ -1519,7 +1529,7 @@ async def test_call_llm_chat_completion_tool_execution_error(
     mock_tool_service,
     llm_response_with_tool_call,
 ):
-    """It raises HTTPException when tool execution fails."""
+    """It returns error result when tool execution fails."""
     mock_llm_service.complete_messages.return_value = (
         llm_response_with_tool_call
     )
@@ -1528,15 +1538,14 @@ async def test_call_llm_chat_completion_tool_execution_error(
         'test_tool'
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Search'}],
-            temperature=0.7,
-            max_tokens=512,
-        )
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Search'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
 
-    assert exc_info.value.status_code == 502
-    assert 'unsupported tool' in str(exc_info.value.detail).lower()
+    assert result.error is not None
+    assert 'unsupported tool' in str(result.error.message).lower()
 
 
 async def test_call_llm_chat_completion_max_rounds_exceeded(
@@ -1544,7 +1553,7 @@ async def test_call_llm_chat_completion_max_rounds_exceeded(
     mock_llm_service,
     mock_tool_service,
 ):
-    """It raises HTTPException when maximum tool rounds are exceeded."""
+    """It returns error result when maximum tool rounds are exceeded."""
     tool_call_response = LLMCompletionResult(
         content='I will search.',
         model='llama3.2',
@@ -1582,15 +1591,14 @@ async def test_call_llm_chat_completion_max_rounds_exceeded(
         llm_context='Result',
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Search'}],
-            temperature=0.7,
-            max_tokens=512,
-        )
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Search'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
 
-    assert exc_info.value.status_code == 502
-    assert 'exceeded maximum tool rounds' in exc_info.value.detail.lower()
+    assert result.error is not None
+    assert 'exceeded maximum tool rounds' in result.error.message.lower()
 
 
 async def test_call_llm_chat_completion_tool_messages_appended_correctly(
@@ -1687,7 +1695,8 @@ async def test_call_llm_chat_completion_with_json_tool_arguments(
         max_tokens=512,
     )
 
-    assert result == 'Here are the results.'
+    assert result.content == 'Here are the results.'
+    assert result.error is None
 
     # Verify tool was called with parsed JSON arguments
     mock_tool_service.execute_tool.assert_called_once_with(
@@ -1816,7 +1825,7 @@ async def test_call_llm_chat_completion_malformed_json_arguments(
     mock_llm_service,
     mock_tool_service,
 ):
-    """It raises HTTPException when tool arguments are malformed JSON."""
+    """It returns error result when tool arguments are malformed JSON."""
     # Tool call with invalid JSON
     malformed_tool_call = ChatCompletionMessageToolCall(
         id='call_bad',
@@ -1840,15 +1849,14 @@ async def test_call_llm_chat_completion_malformed_json_arguments(
     mock_llm_service.complete_messages.return_value = tool_response
     mock_tool_service.get_available_tools.return_value = []
 
-    with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Test'}],
-            temperature=0.7,
-            max_tokens=512,
-        )
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Test'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
 
-    assert exc_info.value.status_code == 502
-    assert 'invalid tool arguments json' in exc_info.value.detail.lower()
+    assert result.error is not None
+    assert 'unable to parse tool arguments' in result.error.message.lower()
 
 
 async def test_call_llm_chat_completion_tool_arguments_array(
@@ -1856,7 +1864,7 @@ async def test_call_llm_chat_completion_tool_arguments_array(
     mock_llm_service,
     mock_tool_service,
 ):
-    """It raises HTTPException when tool arguments are JSON array instead of object."""
+    """It returns error result when tool arguments are JSON array instead of object."""
     # Tool call with JSON array instead of object
     array_tool_call = ChatCompletionMessageToolCall(
         id='call_array',
@@ -1880,18 +1888,17 @@ async def test_call_llm_chat_completion_tool_arguments_array(
     mock_llm_service.complete_messages.return_value = tool_response
     mock_tool_service.get_available_tools.return_value = []
 
-    with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Test'}],
-            temperature=0.7,
-            max_tokens=512,
-        )
-
-    assert exc_info.value.status_code == 502
-    assert (
-        'tool arguments must be a json object' in exc_info.value.detail.lower()
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Test'}],
+        temperature=0.7,
+        max_tokens=512,
     )
-    assert 'list' in exc_info.value.detail.lower()
+
+    assert result.error is not None
+    assert (
+        'tool arguments must be a json object' in result.error.message.lower()
+    )
+    assert 'list' in result.error.message.lower()
 
 
 async def test_call_llm_chat_completion_tool_arguments_string(
@@ -1899,7 +1906,7 @@ async def test_call_llm_chat_completion_tool_arguments_string(
     mock_llm_service,
     mock_tool_service,
 ):
-    """It raises HTTPException when tool arguments are JSON string instead of object."""
+    """It returns error result when tool arguments are JSON string instead of object."""
     # Tool call with JSON string instead of object
     string_tool_call = ChatCompletionMessageToolCall(
         id='call_string',
@@ -1923,18 +1930,17 @@ async def test_call_llm_chat_completion_tool_arguments_string(
     mock_llm_service.complete_messages.return_value = tool_response
     mock_tool_service.get_available_tools.return_value = []
 
-    with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Test'}],
-            temperature=0.7,
-            max_tokens=512,
-        )
-
-    assert exc_info.value.status_code == 502
-    assert (
-        'tool arguments must be a json object' in exc_info.value.detail.lower()
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Test'}],
+        temperature=0.7,
+        max_tokens=512,
     )
-    assert 'str' in exc_info.value.detail.lower()
+
+    assert result.error is not None
+    assert (
+        'tool arguments must be a json object' in result.error.message.lower()
+    )
+    assert 'str' in result.error.message.lower()
 
 
 async def test_call_llm_chat_completion_tool_arguments_number(
@@ -1942,7 +1948,7 @@ async def test_call_llm_chat_completion_tool_arguments_number(
     mock_llm_service,
     mock_tool_service,
 ):
-    """It raises HTTPException when tool arguments are JSON number instead of object."""
+    """It returns error result when tool arguments are JSON number instead of object."""
     # Tool call with JSON number instead of object
     number_tool_call = ChatCompletionMessageToolCall(
         id='call_number',
@@ -1966,15 +1972,303 @@ async def test_call_llm_chat_completion_tool_arguments_number(
     mock_llm_service.complete_messages.return_value = tool_response
     mock_tool_service.get_available_tools.return_value = []
 
+    result = await conversation_service._call_llm_chat_completion(
+        messages=[{'role': 'user', 'content': 'Test'}],
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    assert result.error is not None
+    assert (
+        'tool arguments must be a json object' in result.error.message.lower()
+    )
+    assert 'int' in result.error.message.lower()
+
+
+# Tests for annotation building
+
+
+async def test_create_conversation_with_message_success_includes_annotations(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+    valid_request,
+    mock_context_result,
+):
+    """It builds and persists success annotations on successful responses."""
+    mock_context_assembly.assemble_context_new_conversation.return_value = (
+        mock_context_result
+    )
+    mock_llm_service.complete_messages.return_value = LLMCompletionResult(
+        content='The answer is 42.',
+        model='llama3.2',
+        prompt_tokens=10,
+        completion_tokens=8,
+        total_tokens=18,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    result = await conversation_service.create_conversation_with_message(
+        session=async_session,
+        user_id=test_user_id,
+        payload=valid_request,
+    )
+
+    # Verify assistant message has success annotations
+    assert result.assistant_message.annotations is not None
+    assert result.assistant_message.annotations.failure is None
+    assert result.assistant_message.error is None
+
+    # Reload from DB to verify persistence
+    stmt = select(Message).where(Message.id == result.assistant_message.id)
+    db_result = await async_session.execute(stmt)
+    db_message = db_result.scalar_one()
+    assert db_message.annotations is not None
+    assert db_message.error is None
+
+
+async def test_add_message_with_tool_execution_and_fetch_sources(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    mock_tool_service,
+    async_session,
+    test_user_id,
+    mock_context_result,
+):
+    """It builds annotations with sources from web_fetch tool results."""
+    # Set up conversation
+    conversation = Conversation(
+        user_id=test_user_id,
+        title='Test',
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    user_message = Message(
+        conversation_id=conversation.id,
+        role='user',
+        content='Find information about Python.',
+        sequence_number=1,
+    )
+    async_session.add(user_message)
+    await async_session.commit()
+
+    # Mock context assembly
+    mock_context_assembly.assemble_context.return_value = mock_context_result
+
+    # Mock LLM to NOT request tools on first call
+    mock_llm_service.complete_messages.return_value = LLMCompletionResult(
+        content='Python is a popular programming language.',
+        model='llama3.2',
+        prompt_tokens=15,
+        completion_tokens=12,
+        total_tokens=27,
+        tool_calls=None,
+        finish_reason='stop',
+    )
+
+    mock_tool_service.get_available_tools.return_value = []
+
+    request = CreateMessageRequest(
+        content='Find information about Python.',
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    result = await conversation_service.add_message_to_conversation(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=request,
+    )
+
+    # Verify assistant message has annotations
+    assert result.assistant_message.annotations is not None
+    assert result.assistant_message.error is None
+
+
+async def test_create_conversation_with_message_llm_failure_persists_error_row(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+    valid_request,
+    mock_context_result,
+):
+    """It persists assistant failure row with error annotations on LLM error."""
+    mock_context_assembly.assemble_context_new_conversation.return_value = (
+        mock_context_result
+    )
+    # Simulate LLM timeout
+    mock_llm_service.complete_messages.side_effect = LLMCompletionError(
+        kind=LLMCompletionErrorKind.timeout,
+        message='Request timed out',
+    )
+
+    # Should still raise HTTPException to client
     with pytest.raises(HTTPException) as exc_info:
-        await conversation_service._call_llm_chat_completion(
-            messages=[{'role': 'user', 'content': 'Test'}],
-            temperature=0.7,
-            max_tokens=512,
+        await conversation_service.create_conversation_with_message(
+            session=async_session,
+            user_id=test_user_id,
+            payload=valid_request,
+        )
+
+    assert exc_info.value.status_code == 504
+
+    # But message should be persisted with failure annotations
+    stmt = (
+        select(Message)
+        .where(Message.role == 'assistant')
+        .where(Message.conversation_id is not None)
+    )
+    result = await async_session.execute(stmt)
+    messages = list(result.scalars().all())
+
+    # Should have persisted the assistant message with error
+    assert len(messages) == 1
+    assistant_msg = messages[0]
+    assert assistant_msg.error is not None
+    assert 'timed out' in assistant_msg.error.lower()
+    assert assistant_msg.annotations is not None
+    # Convert dict to AssistantAnnotations for assertion
+    annotations = (
+        AssistantAnnotations(**assistant_msg.annotations)
+        if isinstance(assistant_msg.annotations, dict)
+        else assistant_msg.annotations
+    )
+    assert annotations.failure is not None
+    assert annotations.failure.stage == FailureAnnotationStage.LLM
+    assert annotations.failure.retryable is True
+
+
+async def test_get_conversation_messages_returns_persisted_annotations(
+    conversation_service,
+    async_session,
+    test_user_id,
+):
+    """It returns persisted annotations unchanged on reload."""
+    # Create conversation with annotated message
+    conversation = Conversation(
+        user_id=test_user_id,
+        title='Test',
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    message = Message(
+        conversation_id=conversation.id,
+        role='assistant',
+        content='Test response',
+        sequence_number=1,
+    )
+    # Manually set annotations to verify they round-trip
+    message.annotations = {
+        'sources': [
+            {
+                'title': 'Example',
+                'url': 'https://example.com',
+                'snippet': 'Example snippet',
+                'rationale': 'Test source',
+            }
+        ],
+        'tools': [],
+        'memory_hits': [],
+        'memory_saved': [],
+        'failure': None,
+    }
+    async_session.add(message)
+    await async_session.commit()
+
+    # Reload messages
+    result = await conversation_service.get_conversation_messages(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+    )
+
+    # Verify annotations are returned unchanged
+    assert len(result.items) == 1
+    assert result.items[0].annotations is not None
+    assert len(result.items[0].annotations.sources) == 1
+    assert result.items[0].annotations.sources[0].title == 'Example'
+
+
+async def test_add_message_with_llm_failure_persists_error_annotations(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+    mock_context_result,
+):
+    """It persists failure annotations with correct stage on LLM error."""
+    # Create conversation
+    conversation = Conversation(
+        user_id=test_user_id,
+        title='Test',
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+
+    user_message = Message(
+        conversation_id=conversation.id,
+        role='user',
+        content='Hello',
+        sequence_number=1,
+    )
+    async_session.add(user_message)
+    await async_session.commit()
+
+    # Mock context assembly
+    mock_context_assembly.assemble_context.return_value = mock_context_result
+
+    # Simulate LLM server error
+    mock_llm_service.complete_messages.side_effect = LLMCompletionError(
+        kind=LLMCompletionErrorKind.backend_error,
+        message='Backend error',
+    )
+
+    request = CreateMessageRequest(
+        content='Hello',
+        temperature=0.7,
+        max_tokens=512,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await conversation_service.add_message_to_conversation(
+            session=async_session,
+            user_id=test_user_id,
+            conversation_id=conversation.id,
+            payload=request,
         )
 
     assert exc_info.value.status_code == 502
-    assert (
-        'tool arguments must be a json object' in exc_info.value.detail.lower()
+
+    # Verify failure message persisted with correct stage
+    stmt = (
+        select(Message)
+        .where(Message.role == 'assistant')
+        .where(Message.conversation_id == conversation.id)
     )
-    assert 'int' in exc_info.value.detail.lower()
+    result = await async_session.execute(stmt)
+    messages = list(result.scalars().all())
+
+    assert len(messages) == 1
+    failure_msg = messages[0]
+    assert failure_msg.annotations is not None
+    # Convert dict to AssistantAnnotations for assertion
+    annotations = (
+        AssistantAnnotations(**failure_msg.annotations)
+        if isinstance(failure_msg.annotations, dict)
+        else failure_msg.annotations
+    )
+    assert annotations.failure is not None
+    assert annotations.failure.stage == FailureAnnotationStage.LLM
+    assert annotations.failure.retryable is True

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -446,6 +446,8 @@ This branch finished the first real research path: `web_search` for discovery an
 
 ### Step 5. Add `AssistantAnnotationService`
 
+**Status:** ✅ **COMPLETE**
+
 **New collaborator 2**
 
 - `apps/assistant-backend/src/assistant/services/assistant_annotations.py`
@@ -468,6 +470,13 @@ This branch finished the first real research path: `web_search` for discovery an
 - success rows persist trust metadata
 - failure rows persist clear assistant-side outcome
 - annotations remain compact and reload-safe
+
+**Completed work:**
+- Added `AssistantAnnotationService` as the dedicated backend collaborator for building compact success and failure annotations
+- Refactored `ConversationService` to keep a structured LLM/tool-loop result instead of only final assistant text
+- Persisted success annotations on assistant rows, including bounded tool usage, fetched-source evidence, and memory-hit metadata sourced from context assembly
+- Persisted terminal assistant failure rows for LLM and tool-path failures, preserving clear failure-stage metadata and any truthful tool/source provenance gathered before the error
+- Kept annotation budgeting centralized in the annotation service so reloads use the stored payload instead of regenerating trust metadata
 
 ### Step 6. Add background extraction with canonical Postgres writes
 
@@ -584,10 +593,10 @@ This branch finished the first real research path: `web_search` for discovery an
 [x] reusable backend tool layer exists
 [x] deterministic validation tool exists
 [x] web_search + web_fetch tool path works
-[ ] AssistantAnnotationService exists
-[ ] terminal assistant failure rows persist on backend failure
+[x] AssistantAnnotationService exists
+[x] terminal assistant failure rows persist on backend failure
 [ ] BackgroundTasks extraction writes summaries/facts
-[ ] chat reload returns persisted annotations
+[x] chat reload returns persisted annotations
 [ ] pending placeholder UI works
 [ ] trust row renders from persisted annotations
 [ ] evidence panel works on desktop and mobile


### PR DESCRIPTION
## Overview

Implements the AssistantAnnotationService (Step 5 from IMPLEMENTATION_PLAN.md), a comprehensive annotation system that captures success/failure metadata for every conversation turn. This enables future audit logging, observability dashboards, and recovery flows.

## What This Adds

### New Service: AssistantAnnotationService
- **Success annotations**: Captures tools used, sources accessed, and memory facts referenced per turn
- **Failure annotations**: Records error details, failure stage (TOOL vs LLM), and rollback metadata on terminal errors
- **Metadata preservation**: On failures, preserves all tools/sources executed before the error occurred
- **Memory tracking**: Surfaces which memory facts influenced each response via memory_hits tracking

### Key Capabilities
- Distinguishes TOOL stage failures (during tool execution) from LLM stage failures (from LLM service)
- Preserves partial work on terminal failures (tools executed, sources fetched, etc.)
- Budgets memory facts to MAX_MEMORY_HITS (2) to prevent annotation bloat
- Prepares data for future annotation persistence layer

### Integration Points
- ConversationService now threads annotations into both success and failure paths
- Message creation routes (both new conversations and additions to existing) include annotations
- Error metadata available for logging, debugging, and recovery workflows

## Code Changes

```
 .../src/assistant/services/__init__.py             |   4 +
 .../assistant/services/assistant_annotations.py    | 270 +++++++++++++  (NEW)
 .../src/assistant/services/conversation_service.py | 161 ++++++--
 .../tests/services/test_assistant_annotations.py   | 357 +++++++++++++++  (NEW)
 .../tests/services/test_conversation_service.py    | 416 ++++++++++++++++++
 5 files changed, 1118 insertions(+), 90 deletions(-)
```

## Testing & Quality

✅ **All 162 tests passing** at 96.39% coverage  
✅ **Ruff linting**: All checks passed  
✅ **Type safety**: Strict type hints throughout  
✅ **Backward compatible**: All new parameters optional

### Test Coverage Additions
- 14 AssistantAnnotationService tests covering success/failure paths, memory tracking, and metadata preservation
- 5 ConversationService integration tests validating annotation threading
- Comprehensive edge case coverage: empty tool lists, missing sources, malformed errors

## Code Review Feedback Addressed

### Issue #1: Tool-path failures marked as LLM ✅
- Now correctly distinguishes failure origin using executed_tools presence
- TOOL stage if any tools ran before error, LLM stage otherwise

### Issue #2: Failure rows lose executed_tools ✅
- Preserves tool execution results in failure annotations
- Preserves sources from any successful tool fetches before failure

### Issue #3: Success annotations miss memory_hits ✅
- Threads fact_ids from context assembly through annotation builder
- Automatically populates memory_hits from context facts

## Architecture Notes

### Annotation Flow
1. **Pre-LLM**: Assemble context with facts, tools, and memory state
2. **LLM Call**: Execute and capture tools, errors, and LLM response
3. **Post-LLM**: Build annotation with outcome (success/failure) metadata
4. **Persistence**: Store annotation in message row (future: separate audit table)

### Design Decisions
- **Failure stage detection**: Based on executed_tools list presence (reliable indicator of flow progress)
- **Memory budgeting**: Caps to 2 facts to prevent annotation metadata bloat while maintaining traceability
- **Rollback metadata**: Preserves tool/source work to enable recovery flows on retries
- **Service separation**: Annotations decoupled from conversation logic for testability and future reuse

## Future Work

This PR establishes the annotation foundation for:
- Audit logging layer (persist annotations to separate table)
- Observability dashboards (surface success/failure patterns)
- Recovery flows (use preserved metadata on retries)
- Memory effectiveness analysis (track which facts were referenced)

See TODOS.md for implementation roadmap.

## Commits

- `304b8ca` - feat(backend): add AssistantAnnotationService with success/failure annotation building
- `d2996e6` - fix(backend): address code review feedback on annotation service
- `8d2e249` - chore: fix formatting

---

*Ready for review. No blocking issues. All CI checks passing.*