### PR TITLE
chore: harden conversation contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,5 @@ See individual READMEs for detailed instructions:
 
 - [Architecture](docs/ARCHITECTURE.md)
 - [Implementation Plan](docs/IMPLEMENTATION_PLAN.md)
-- [Step 6 Notes: Atomic Postgres Memory Writes](STEP_6_IMPLEMENTATION_NOTES.md)
-- [Step 6 Notes: Chroma Indexing Mirror](STEP_6_CHROMA_INDEXING_SUMMARY.md)
-- [Step 6 Notes: Context Assembly Improvements](STEP_6_CONTEXT_ASSEMBLY_IMPROVEMENTS.md)
 - [Design System](DESIGN.md)
 - [Roadmap / TODOs](TODOS.md)

--- a/apps/assistant-backend/tests/routers/test_conversations.py
+++ b/apps/assistant-backend/tests/routers/test_conversations.py
@@ -9,6 +9,28 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
+def build_assistant_annotations() -> dict:
+    return {
+        'sources': [
+            {
+                'title': 'Example Source',
+                'url': 'https://example.com',
+                'snippet': 'Example supporting snippet',
+                'rationale': 'Shows why the source matters',
+            }
+        ],
+        'tools': [{'name': 'web_fetch', 'status': 'completed'}],
+        'memory_hits': [
+            {
+                'label': 'Saved family detail',
+                'summary': 'Matched a previously saved fact',
+            }
+        ],
+        'memory_saved': [],
+        'failure': None,
+    }
+
+
 async def test_list_conversations_success(authenticated_async_test_client):
     """Test successfully listing conversations for a user."""
     conv_id_1 = str(uuid4())
@@ -96,6 +118,8 @@ async def test_get_conversation_messages_success(
                 'content': 'Hello',
                 'sequence_number': 1,
                 'created_at': '2024-01-01T00:00:00Z',
+                'error': None,
+                'annotations': None,
             },
             {
                 'id': msg_id_2,
@@ -103,6 +127,8 @@ async def test_get_conversation_messages_success(
                 'content': 'Hi there!',
                 'sequence_number': 2,
                 'created_at': '2024-01-01T00:00:00Z',
+                'error': None,
+                'annotations': build_assistant_annotations(),
             },
         ],
     }
@@ -126,8 +152,13 @@ async def test_get_conversation_messages_success(
     assert len(data['items']) == 2
     assert data['items'][0]['content'] == 'Hello'
     assert data['items'][0]['role'] == 'user'
+    assert data['items'][0]['annotations'] is None
     assert data['items'][1]['content'] == 'Hi there!'
     assert data['items'][1]['role'] == 'assistant'
+    assert data['items'][1]['annotations'] is not None
+    assert data['items'][1]['annotations']['sources'][0]['title'] == (
+        'Example Source'
+    )
 
 
 async def test_get_conversation_messages_not_found(
@@ -194,6 +225,8 @@ async def test_create_conversation_with_message_success(
             'content': 'What is Python?',
             'sequence_number': 1,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': msg_id_2,
@@ -201,6 +234,8 @@ async def test_create_conversation_with_message_success(
             'sequence_number': 2,
             'content': 'Python is a programming language.',
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': build_assistant_annotations(),
         },
     }
 
@@ -229,10 +264,15 @@ async def test_create_conversation_with_message_success(
     assert 'assistant_message' in data
     assert data['conversation']['title'] == 'Generated Title'
     assert data['user_message']['content'] == 'What is Python?'
+    assert data['user_message']['annotations'] is None
     assert (
         data['assistant_message']['content']
         == 'Python is a programming language.'
     )
+    assert data['assistant_message']['annotations'] is not None
+    assert data['assistant_message']['annotations']['tools'] == [
+        {'name': 'web_fetch', 'status': 'completed'}
+    ]
 
 
 async def test_create_conversation_with_message_default_params(
@@ -255,6 +295,8 @@ async def test_create_conversation_with_message_default_params(
             'content': 'Hello',
             'sequence_number': 1,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': msg_id,
@@ -262,6 +304,8 @@ async def test_create_conversation_with_message_default_params(
             'content': 'Hello',
             'sequence_number': 2,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
     }
 
@@ -393,6 +437,8 @@ async def test_add_message_to_conversation_success(
             'content': 'Follow-up question',
             'sequence_number': 3,
             'created_at': '2024-01-01T00:00:01Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': assistant_msg_id,
@@ -400,6 +446,8 @@ async def test_add_message_to_conversation_success(
             'content': 'Follow-up response',
             'sequence_number': 4,
             'created_at': '2024-01-01T00:00:01Z',
+            'error': None,
+            'annotations': build_assistant_annotations(),
         },
     }
 
@@ -428,7 +476,12 @@ async def test_add_message_to_conversation_success(
     assert 'assistant_message' in data
     assert data['conversation']['id'] == conv_id
     assert data['user_message']['content'] == 'Follow-up question'
+    assert data['user_message']['annotations'] is None
     assert data['assistant_message']['content'] == 'Follow-up response'
+    assert data['assistant_message']['annotations'] is not None
+    assert data['assistant_message']['annotations']['memory_hits'][0][
+        'label'
+    ] == 'Saved family detail'
 
 
 async def test_add_message_to_conversation_default_params(
@@ -450,6 +503,8 @@ async def test_add_message_to_conversation_default_params(
             'content': 'Hello',
             'sequence_number': 1,
             'created_at': '2024-01-01T00:00:01Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': str(uuid4()),
@@ -457,6 +512,8 @@ async def test_add_message_to_conversation_default_params(
             'content': 'Hi',
             'sequence_number': 2,
             'created_at': '2024-01-01T00:00:01Z',
+            'error': None,
+            'annotations': None,
         },
     }
 
@@ -627,6 +684,8 @@ async def test_create_conversation_with_message_passes_background_tasks(
             'content': 'Hello',
             'sequence_number': 1,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': str(uuid4()),
@@ -634,6 +693,8 @@ async def test_create_conversation_with_message_passes_background_tasks(
             'content': 'Hi!',
             'sequence_number': 2,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
     }
 
@@ -679,6 +740,8 @@ async def test_add_message_to_conversation_passes_background_tasks(
             'content': 'Follow-up',
             'sequence_number': 3,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
         'assistant_message': {
             'id': str(uuid4()),
@@ -686,6 +749,8 @@ async def test_add_message_to_conversation_passes_background_tasks(
             'content': 'Response',
             'sequence_number': 4,
             'created_at': '2024-01-01T00:00:00Z',
+            'error': None,
+            'annotations': None,
         },
     }
 

--- a/apps/assistant-ui/src/lib/api.test.ts
+++ b/apps/assistant-ui/src/lib/api.test.ts
@@ -5,6 +5,26 @@ import * as api from "./api";
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch as typeof fetch;
 
+const populatedAssistantAnnotations = {
+  sources: [
+    {
+      title: "Example Source",
+      url: "https://example.com",
+      snippet: "Example supporting snippet",
+      rationale: "Explains why the source matters",
+    },
+  ],
+  tools: [{ name: "web_fetch", status: "completed" as const }],
+  memory_hits: [
+    {
+      label: "Saved family detail",
+      summary: "Matched a previously saved fact",
+    },
+  ],
+  memory_saved: [],
+  failure: null,
+};
+
 describe("API client", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -196,6 +216,16 @@ describe("API client", () => {
             sequence_number: 1,
             created_at: "2024-01-01T00:00:00Z",
             error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Hi there!",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:01Z",
+            error: null,
+            annotations: populatedAssistantAnnotations,
           },
         ],
       };
@@ -216,6 +246,8 @@ describe("API client", () => {
       );
 
       expect(result).toEqual(mockResponse);
+      expect(result.items[0].annotations).toBeNull();
+      expect(result.items[1].annotations).toEqual(populatedAssistantAnnotations);
     });
 
     it("throws UNAUTHORIZED error on 401 response", async () => {
@@ -269,6 +301,7 @@ describe("API client", () => {
           sequence_number: 1,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-2",
@@ -277,6 +310,7 @@ describe("API client", () => {
           sequence_number: 2,
           created_at: "2024-01-01T00:00:00Z",
           error: null,
+          annotations: populatedAssistantAnnotations,
         },
       };
 
@@ -300,6 +334,10 @@ describe("API client", () => {
       );
 
       expect(result).toEqual(mockResponse);
+      expect(result.user_message.annotations).toBeNull();
+      expect(result.assistant_message.annotations).toEqual(
+        populatedAssistantAnnotations,
+      );
     });
 
     it("throws UNAUTHORIZED error on 401 response", async () => {
@@ -342,6 +380,7 @@ describe("API client", () => {
           sequence_number: 3,
           created_at: "2024-01-01T00:01:00Z",
           error: null,
+          annotations: null,
         },
         assistant_message: {
           id: "msg-4",
@@ -350,6 +389,7 @@ describe("API client", () => {
           sequence_number: 4,
           created_at: "2024-01-01T00:01:00Z",
           error: null,
+          annotations: null,
         },
       };
 

--- a/apps/assistant-ui/src/lib/api.test.ts
+++ b/apps/assistant-ui/src/lib/api.test.ts
@@ -247,7 +247,9 @@ describe("API client", () => {
 
       expect(result).toEqual(mockResponse);
       expect(result.items[0].annotations).toBeNull();
-      expect(result.items[1].annotations).toEqual(populatedAssistantAnnotations);
+      expect(result.items[1].annotations).toEqual(
+        populatedAssistantAnnotations,
+      );
     });
 
     it("throws UNAUTHORIZED error on 401 response", async () => {


### PR DESCRIPTION
## Summary
- harden frontend API and backend router test fixtures so they match the current conversation message contract, including nullable and populated assistant annotations
- ignore  so local backend lockfiles stop showing up as stray untracked files
- remove stale Step 6 note links from the root README during the release review

## Testing
- 
- 

## Documentation
- : removed dead links to non-existent Step 6 notes
