### PR TITLE
Add PRD for curated model presets

### DIFF
--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -262,6 +262,7 @@ The initial UI change is intentionally small:
 
 - add a dropdown selector near the message composer
 - fetch presets from the backend
+- show the curated preset label in the dropdown
 - remember the last selected preset locally for convenience
 - send the chosen preset id with each message
 
@@ -270,6 +271,15 @@ Future UI enhancements may include:
 - preset descriptions
 - reasoning indicators
 - optional reasoning disclosure panels
+
+The UI does not need to enforce a strict naming philosophy for preset
+labels.
+
+The label should be whatever makes sense to the developer and the
+intended users, as long as it is clear enough in the dropdown.
+
+The underlying model name remains backend metadata and does not need to
+appear in the primary model selector UI.
 
 ## Reasoning Display Policy
 
@@ -356,8 +366,6 @@ We should add coverage for:
 - Do we want one extraction preset globally, or per user-facing preset?
 - When Gemma presets are introduced, should we use Ollama-native
   reasoning controls, prompt tokens, or both?
-- Should the UI expose only human-friendly labels, or also show the
-  underlying model name for debugging?
 
 ## Recommended First Milestone
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -421,26 +421,34 @@ controls, prompt tokens, or both?
   Ollama's native support for a specific model's reasoning mode is missing or
   inconsistent.
 
-### How do we ensure correct prompting across multiple models?
+### Should reasoning traces be persisted?
 
-**Question:** When we support multiple models, how shall we ensure we prompt the
-model correctly?
+**Question:** Should reasoning traces ever be persisted beyond transient UI metadata?
 
-**Recommendation:** Implement an **Adapter Pattern** at the LLM service layer to
-decouple conversation logic from model-specific implementation details.
+**Recommendation:** Yes, reasoning traces should be persisted as **structured metadata**
+within the assistant message's `annotations` field, but kept separate from the
+canonical `content`.
 
-1.  **Preset Registry:** Centralize configuration mapping each preset to a
-    specific model ID and its associated strategies.
-2.  **Request Adapters:** Responsible for selecting the system prompt, injecting
-    model-specific control tokens, and setting appropriate request parameters (like
-    `temperature` or `think: true`).
-3.  **Response Adapters:** Responsible for extracting the final user-facing
-    content, normalizing reasoning traces into standard metadata, and stripping
-    any model-specific artifacts before persistence.
+- **Why:** Persisting reasoning traces enables debugging, model evaluation, and
+  features like "Show Thinking" for past messages in the UI.
+- **Policy:** While persisted, these traces should **not** be included in the
+  conversation history sent back to the LLM in future turns. This prevents
+  "context contamination" and keeps the prompt focused on the actual dialogue.
 
-This approach ensures that the core conversation service remains model-agnostic
-while allowing each model to be prompted and parsed according to its unique
-behavior.
+### Global vs. Per-Preset Extraction
+
+**Question:** Do we want one extraction preset globally, or per user-facing preset?
+
+**Recommendation:** We should use a **global default extraction preset** with the
+capability for **per-preset overrides** in the registry.
+
+- **Why:** For most chat presets, a single stable model (like `qwen2.5:7b`) is the
+  most reliable for memory extraction. However, specialized presets (e.g., for
+  coding or structured data) may eventually require specialized extraction models
+  or prompts.
+- **Implementation:** The `ModelPresetRegistry` should include an optional
+  `memory_extraction_preset` field. If omitted, the system falls back to the
+  configured global default.
 
 ## Recommended First Milestone
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -403,12 +403,44 @@ We should add coverage for:
 - extraction preset resolution
 - mixed-preset conversation flows
 
-## Open Questions
+## Open Questions & Proposed Answers
 
-- Should reasoning traces ever be persisted beyond transient UI metadata?
-- Do we want one extraction preset globally, or per user-facing preset?
-- When Gemma presets are introduced, should we use Ollama-native
-  reasoning controls, prompt tokens, or both?
+### How should we handle Gemma reasoning controls?
+
+**Question:** When Gemma presets are introduced, should we use Ollama-native reasoning
+controls, prompt tokens, or both?
+
+**Recommendation:** We should **prefer Ollama-native reasoning controls** (using the
+`think` parameter) when they are supported by Ollama for the specific Gemma variant.
+
+- **Why:** It provides a cleaner request structure and lets the backend handle
+  model-specific token updates. Most importantly, it allows the reasoning trace to
+  be returned in a separate field, simplifying the process of extracting clean
+  content for persistence.
+- **Fallback:** We should **fallback to prompt tokens** (manual tag injection) only if
+  Ollama's native support for a specific model's reasoning mode is missing or
+  inconsistent.
+
+### How do we ensure correct prompting across multiple models?
+
+**Question:** When we support multiple models, how shall we ensure we prompt the
+model correctly?
+
+**Recommendation:** Implement an **Adapter Pattern** at the LLM service layer to
+decouple conversation logic from model-specific implementation details.
+
+1.  **Preset Registry:** Centralize configuration mapping each preset to a
+    specific model ID and its associated strategies.
+2.  **Request Adapters:** Responsible for selecting the system prompt, injecting
+    model-specific control tokens, and setting appropriate request parameters (like
+    `temperature` or `think: true`).
+3.  **Response Adapters:** Responsible for extracting the final user-facing
+    content, normalizing reasoning traces into standard metadata, and stripping
+    any model-specific artifacts before persistence.
+
+This approach ensures that the core conversation service remains model-agnostic
+while allowing each model to be prompted and parsed according to its unique
+behavior.
 
 ## Recommended First Milestone
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -2,18 +2,24 @@
 
 ## Summary
 
-This document defines the first implementation plan for user-selectable
-model presets in Family Assistant.
+This document defines the implementation plan for user-selectable model
+presets in Family Assistant.
 
 The product goal is to let users choose between a small curated set of
 assistant modes per message, while keeping model-specific prompt
 construction, reasoning controls, response parsing, and memory extraction
 logic behind backend abstractions.
 
-This work is both:
+## Prerequisites
 
-- a learning project for experimenting with multiple local model setups
-- a foundation for a real product feature with stable UI behavior
+This work assumes the following capabilities have been implemented
+independently:
+
+- **Streaming Support:** The backend and frontend must support Server-Sent
+  Events (SSE) for real-time response generation.
+- **Multimodal (Vision) Support:** The system is assumed to have a base
+  capability for image handling (upload, storage, and model-native
+  payloads) if multimodal presets are to be included.
 
 ## Product Goals
 
@@ -33,7 +39,8 @@ This work is both:
 - Exposing every locally installed Ollama model directly to end users
 - Committing to one universal reasoning token format across models
 - Refactoring the full memory storage schema up front
-- Solving image generation in this scope
+- **Implementing Streaming or Image Storage:** These are treated as
+  independent architectural prerequisites.
 
 ## Confirmed Product Decisions
 
@@ -117,28 +124,30 @@ configuration, not an implicit copy of the visible chat preset.
 
 ## Capability-Specific Handling
 
+The system adapts its behavior based on the `capabilities` defined in the
+preset registry, assuming the necessary independent prerequisites (like
+Streaming and Vision) are active.
+
 ### Multimodal (Vision) Support
 
-When a preset includes the `vision` capability:
+If a preset includes the `vision` capability:
 
-- **Request Payload:** The frontend should include image attachments in the
-  `user_message` payload.
-- **Request Adapter:** The adapter is responsible for formatting the images into the
-  standard message content shape (e.g., using `image_url` or base64 data) required
-  by the LLM backend.
-- **Validation:** The backend should reject messages with image attachments if the
-  selected preset does not explicitly declare `vision` capability.
+- **Request Payload:** The frontend includes image attachments in the
+  `user_message` payload (handled by the independent Vision project).
+- **Request Adapter:** The adapter formats the images into the required
+  Ollama/OpenAI payload shape.
+- **Validation:** The backend rejects image attachments if the selected
+  preset lacks the `vision` capability.
 
 ### Streaming for Reasoning Presets
 
-Reasoning models (like `thinking` presets) can have significantly higher latency
-due to long-running thought traces.
+Reasoning models (like `thinking` presets) benefit from real-time feedback
+as thought traces are generated.
 
-- **Policy:** Presets that support reasoning **should prioritize streaming** to
-  provide immediate feedback to the user.
-- **Thought Disclosure:** The streaming implementation should distinguish between
-  "thinking" tokens and "content" tokens, allowing the UI to render the reasoning
-  trace in a distinct (often collapsible) area as it arrives.
+- **Policy:** Presets with `reasoning` capabilities use the independent
+  Streaming infrastructure to show thought traces as they arrive.
+- **Thought Disclosure:** The response adapter identifies and separates
+  "thinking" tokens from "content" tokens for distinct UI rendering.
 
 ## Proposed Solution
 
@@ -416,15 +425,6 @@ Decouple memory extraction from the user-facing preset.
   - Registry-driven extraction preset resolver.
   - Update `extract_and_save_background` to use the configured extraction preset.
   - Tests verifying extraction consistency regardless of chat preset.
-
-### Phase 7: Multimodal (Vision) Support
-
-Add the capability for image-based conversation presets.
-
-- **Deliverables:**
-  - `VisionModelAdapter` for image formatting.
-  - Backend validation for image payloads vs. preset capabilities.
-  - Registry update with a `vision` preset.
 
 ## Testing Strategy
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -499,3 +499,13 @@ The smallest meaningful slice is:
 
 That gives us a real user-facing feature and the core abstraction seam
 without forcing all model-specific parsing work into the first pass.
+
+## References
+
+- **Ollama:** [https://ollama.com/](https://ollama.com/)
+- **Ollama API (Search for `think`):** [https://ollama.com/blog/v0.9](https://ollama.com/blog/v0.9)
+- **Gemma 4:** [https://ai.google.dev/gemma](https://ai.google.dev/gemma)
+- **Qwen 2.5:** [https://qwenlm.github.io/blog/qwen2.5/](https://qwenlm.github.io/blog/qwen2.5/)
+- **Adapter Pattern:** [https://refactoring.guru/design-patterns/adapter](https://refactoring.guru/design-patterns/adapter)
+- **Pydantic:** [https://docs.pydantic.dev/](https://docs.pydantic.dev/)
+- **OpenAI Chat Completions API:** [https://platform.openai.com/docs/api-reference/chat](https://platform.openai.com/docs/api-reference/chat)

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -1,0 +1,375 @@
+# Model Presets PRD
+
+## Summary
+
+This document defines the first implementation plan for user-selectable
+model presets in Family Assistant.
+
+The product goal is to let users choose between a small curated set of
+assistant modes per message, while keeping model-specific prompt
+construction, reasoning controls, response parsing, and memory extraction
+logic behind backend abstractions.
+
+This work is both:
+
+- a learning project for experimenting with multiple local model setups
+- a foundation for a real product feature with stable UI behavior
+
+## Product Goals
+
+- Let the user choose between `2-3` curated presets from the chat UI.
+- Support presets that may point to:
+  - the same base model with different behavior such as `quick` vs
+    `thinking`
+  - different Ollama models entirely
+- Apply the selected preset per message, not per conversation.
+- Keep the UI simple with a dropdown model selector near the message
+  composer.
+- Allow experimentation with prompt construction, reasoning controls,
+  response parsing, and extraction models without changing the UI
+  contract.
+
+## Non-Goals
+
+- Exposing every locally installed Ollama model directly to end users
+- Committing to one universal reasoning token format across models
+- Refactoring the full memory storage schema up front
+- Solving image generation in this scope
+
+## Confirmed Product Decisions
+
+- Preset selection is per message.
+- The first UI can be a simple dropdown below or beside the text input.
+- Initial presets may all point at the same base model.
+- Curated presets only; no raw Ollama model picker in the main product
+  UI.
+- The curated preset list can live in the repository as checked-in
+  configuration.
+- Memory extraction should remain configurable and may later use a
+  simpler or smaller model than the user-facing reply preset.
+
+## Problem Statement
+
+The current backend assumes a single configured model and a mostly
+uniform request and response shape.
+
+That assumption breaks down once we support:
+
+- multiple user-facing model options
+- different reasoning modes for the same model
+- model-specific prompt controls such as Gemma thinking tokens
+- model-specific response parsing rules
+- future experimentation with separate extraction models
+
+We need a design that keeps the product surface stable while allowing the
+backend to adapt to model-specific behavior.
+
+## Key Technical Observations
+
+### Presets should be the product surface
+
+The user should select from app-defined presets, not raw model names.
+
+This lets us present a stable UI contract such as:
+
+- `Quick`
+- `Thinking`
+- `Balanced`
+
+without forcing the UI to understand Ollama-specific model behavior.
+
+### Reasoning controls are not universal
+
+We should not assume that `<think>`-style or `<|think|>`-style control
+tokens are universal across models.
+
+Some models can be controlled through Ollama-native request fields such
+as `think`, while others may require prompt-level conventions or emit
+model-specific thought markers.
+
+This means reasoning behavior must be handled by backend adapters, not by
+hardcoded UI logic.
+
+### Response parsing may vary by preset
+
+Different presets may require different response parsing strategies.
+
+Examples:
+
+- plain content extraction
+- Ollama-native `thinking` field handling
+- model-specific tag stripping
+- tool-call normalization
+
+### Memory extraction is a separate concern
+
+The user-selected reply preset should not automatically determine the
+model used for summary and durable-fact extraction.
+
+Extraction has different goals:
+
+- predictable formatting
+- lower cost
+- lower latency
+- fewer reasoning artifacts
+
+We should therefore treat extraction model selection as preset-driven
+configuration, not an implicit copy of the visible chat preset.
+
+## Proposed Solution
+
+### Curated preset registry
+
+Introduce a checked-in backend registry of user-facing model presets.
+
+The initial implementation can use a Python module or JSON file in the
+repository.
+
+Each preset should define:
+
+- `id`
+- `label`
+- `description`
+- `ollama_model`
+- `reasoning_mode`
+- `capabilities`
+- `request_strategy`
+- `response_strategy`
+- `show_reasoning_in_ui`
+- `memory_extraction_preset`
+
+Example conceptual presets:
+
+- `qwen-quick`
+- `qwen-thinking`
+- `qwen-balanced`
+
+All three may initially map to `qwen2.5` while differing in behavior.
+
+### Backend preset API
+
+Add a backend endpoint for the UI to query the curated preset list.
+
+Initial endpoint:
+
+```text
+GET /api/v1/model-presets
+```
+
+The response should include only curated presets approved for the
+product.
+
+It should not expose the raw set of locally installed Ollama models in
+the main UI path.
+
+### Request adapter layer
+
+Introduce a model preset request adapter that is responsible for:
+
+- constructing the final prompt or system prompt
+- applying reasoning controls for the selected preset
+- choosing the appropriate Ollama request shape
+- passing through model-specific request options
+
+This layer keeps prompt-generation logic out of the conversation route
+handlers and out of the UI.
+
+### Response adapter layer
+
+Introduce a matching response adapter that is responsible for:
+
+- extracting final assistant content
+- extracting reasoning traces when available
+- stripping model-specific markers from persisted message content
+- normalizing metadata for annotations or UI rendering
+
+This layer should define what gets:
+
+- shown to the user as the main response
+- optionally shown as reasoning
+- persisted into conversation history
+- fed back into the next turn
+
+### Per-message preset selection
+
+Each user message should carry the selected preset identifier.
+
+Each assistant message should record:
+
+- preset id used
+- underlying model used
+- any reasoning mode metadata needed for debugging or analysis
+
+This allows mixed-preset conversations while preserving traceability.
+
+### Memory extraction configuration
+
+Keep the current extraction path, but move toward a dedicated extraction
+preset configuration.
+
+Initial behavior:
+
+- continue using `qwen2.5` for extraction
+- make the extraction preset configurable in the registry
+
+Future behavior:
+
+- experiment with smaller or more stable extraction models
+- tune extraction parameters independently from user-facing reply presets
+
+## Architecture Changes
+
+### New concepts
+
+- `ModelPresetRegistry`
+- `ModelRequestAdapter`
+- `ModelResponseAdapter`
+- `ExtractionPresetResolver`
+
+### Existing areas likely touched
+
+- backend settings and configuration loading
+- chat and conversation request models
+- LLM service orchestration
+- conversation persistence
+- assistant annotations
+- background memory extraction flow
+- frontend composer UI
+- frontend API client and types
+- tests across backend and frontend
+
+## Data Model Implications
+
+We should plan for message-level metadata that records preset usage.
+
+At minimum, we likely need assistant and or user message metadata for:
+
+- selected preset id
+- resolved model id
+- reasoning mode
+
+This may require either:
+
+- extending the canonical message schema
+- or introducing a small structured metadata field if we want to avoid
+  multiple new columns
+
+The exact schema decision is still open.
+
+## UI Changes
+
+The initial UI change is intentionally small:
+
+- add a dropdown selector near the message composer
+- fetch presets from the backend
+- remember the last selected preset locally for convenience
+- send the chosen preset id with each message
+
+Future UI enhancements may include:
+
+- preset descriptions
+- reasoning indicators
+- optional reasoning disclosure panels
+
+## Reasoning Display Policy
+
+Initial recommendation:
+
+- persist clean final assistant content as the canonical message body
+- do not include prior reasoning traces in normal conversation history
+- treat reasoning as optional metadata for display or debugging
+
+This avoids contaminating future turns and memory extraction with raw
+thought traces.
+
+## Rollout Plan
+
+### Phase 1
+
+Create the preset registry and backend preset API.
+
+Deliverables:
+
+- checked-in preset config
+- preset registry loader
+- `GET /api/v1/model-presets`
+
+### Phase 2
+
+Add per-message preset selection end to end.
+
+Deliverables:
+
+- frontend dropdown selector
+- request payload updates
+- backend handling of preset id per message
+- persistence of preset metadata
+
+### Phase 3
+
+Introduce request and response adapter abstractions.
+
+Deliverables:
+
+- adapter interfaces
+- default adapter for current `qwen2.5` behavior
+- first reasoning-capable adapter path
+
+### Phase 4
+
+Separate extraction preset configuration from user-facing reply preset
+selection.
+
+Deliverables:
+
+- extraction preset config
+- extraction path reads configured preset
+- tests covering extraction independence
+
+### Phase 5
+
+Experiment with additional presets and model-specific parsing behavior.
+
+Deliverables:
+
+- Gemma-specific preset support if adopted
+- reasoning visibility decisions in the UI
+- tuning and evaluation notes
+
+## Testing Strategy
+
+We should add coverage for:
+
+- preset API contract
+- per-message preset transport
+- request adapter behavior
+- response parsing behavior
+- persistence of preset metadata
+- extraction preset resolution
+- mixed-preset conversation flows
+
+## Open Questions
+
+- Should preset metadata be stored in dedicated message columns or in a
+  structured metadata field?
+- Should reasoning traces ever be persisted beyond transient UI metadata?
+- Do we want one extraction preset globally, or per user-facing preset?
+- When Gemma presets are introduced, should we use Ollama-native
+  reasoning controls, prompt tokens, or both?
+- Should the UI expose only human-friendly labels, or also show the
+  underlying model name for debugging?
+
+## Recommended First Milestone
+
+The smallest meaningful slice is:
+
+- checked-in curated preset registry
+- preset list API
+- composer dropdown
+- per-message preset id transport
+- preset metadata persistence
+- default `qwen2.5` adapter
+- extraction continues using `qwen2.5`
+
+That gives us a real user-facing feature and the core abstraction seam
+without forcing all model-specific parsing work into the first pass.

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -116,6 +116,31 @@ Extraction has different goals:
 We should therefore treat extraction model selection as preset-driven
 configuration, not an implicit copy of the visible chat preset.
 
+## Capability-Specific Handling
+
+### Multimodal (Vision) Support
+
+When a preset includes the `vision` capability:
+
+- **Request Payload:** The frontend should include image attachments in the
+  `user_message` payload.
+- **Request Adapter:** The adapter is responsible for formatting the images into the
+  standard message content shape (e.g., using `image_url` or base64 data) required
+  by the LLM backend.
+- **Validation:** The backend should reject messages with image attachments if the
+  selected preset does not explicitly declare `vision` capability.
+
+### Streaming for Reasoning Presets
+
+Reasoning models (like `thinking` presets) can have significantly higher latency
+due to long-running thought traces.
+
+- **Policy:** Presets that support reasoning **should prioritize streaming** to
+  provide immediate feedback to the user.
+- **Thought Disclosure:** The streaming implementation should distinguish between
+  "thinking" tokens and "content" tokens, allowing the UI to render the reasoning
+  trace in a distinct (often collapsible) area as it arrives.
+
 ## Proposed Solution
 
 ### Curated preset registry
@@ -141,10 +166,9 @@ Each preset should define:
 Field intent:
 
 - `capabilities`
-  - a structured description of what the preset can support, such as
-    reasoning, tools, or vision
+  - a list of features supported by the preset (e.g., `["text", "vision", "tools", "reasoning"]`)
   - used by the backend to validate behavior and by the UI to decide
-    whether optional affordances should appear
+    whether optional affordances (like image upload) should appear
 - `request_strategy`
   - a stable identifier for the request adapter behavior used to build
     prompts and reasoning controls for this preset
@@ -311,20 +335,16 @@ The initial UI change is intentionally small:
 - remember the last selected preset locally for convenience
 - send the chosen preset id with each message
 
-Future UI enhancements may include:
+### Preset Transition Logic
 
-- preset descriptions
-- reasoning indicators
-- optional reasoning disclosure panels
+The UI must adapt its composer state when a user switches presets:
 
-The UI does not need to enforce a strict naming philosophy for preset
-labels.
-
-The label should be whatever makes sense to the developer and the
-intended users, as long as it is clear enough in the dropdown.
-
-The underlying model name remains backend metadata and does not need to
-appear in the primary model selector UI.
+- **Capability Enforcement:** If a user switches from a `vision`-capable preset to a
+  text-only preset, the UI should warn the user that current image attachments
+  will be ignored or removed.
+- **Visual Cues:** The UI should use subtle indicators (e.g., a "Thinking" badge or
+  an "Image Supported" icon) to reflect the capabilities of the currently active
+  preset.
 
 ## Reasoning Display Policy
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -248,13 +248,26 @@ At minimum, we likely need assistant and or user message metadata for:
 - resolved model id
 - reasoning mode
 
-This may require either:
+Recommended initial approach:
 
-- extending the canonical message schema
-- or introducing a small structured metadata field if we want to avoid
-  multiple new columns
+- store preset usage in a structured message metadata field
+- avoid adding multiple dedicated columns in the first iteration
 
-The exact schema decision is still open.
+This gives us flexibility while we experiment with which fields are
+actually useful to persist.
+
+Example shape:
+
+```json
+{
+  "preset_id": "qwen-thinking",
+  "resolved_model": "qwen2.5:7b",
+  "reasoning_mode": "thinking"
+}
+```
+
+We can later promote stable high-value fields such as `preset_id` to
+dedicated columns if querying, indexing, or analytics needs justify it.
 
 ## UI Changes
 
@@ -360,8 +373,6 @@ We should add coverage for:
 
 ## Open Questions
 
-- Should preset metadata be stored in dedicated message columns or in a
-  structured metadata field?
 - Should reasoning traces ever be persisted beyond transient UI metadata?
 - Do we want one extraction preset globally, or per user-facing preset?
 - When Gemma presets are introduced, should we use Ollama-native

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -23,8 +23,7 @@ This work is both:
     `thinking`
   - different Ollama models entirely
 - Apply the selected preset per message, not per conversation.
-- Keep the UI simple with a dropdown model selector near the message
-  composer.
+- The UI features a dropdown model selector near the message composer.
 - Allow experimentation with prompt construction, reasoning controls,
   response parsing, and extraction models without changing the UI
   contract.
@@ -39,14 +38,14 @@ This work is both:
 ## Confirmed Product Decisions
 
 - Preset selection is per message.
-- The first UI can be a simple dropdown below or beside the text input.
+- The initial UI is a dropdown below or beside the text input.
 - Initial presets may all point at the same base model.
 - Curated presets only; no raw Ollama model picker in the main product
   UI.
-- The curated preset list can live in the repository as checked-in
+- The curated preset list lives in the repository as checked-in
   configuration.
-- Memory extraction should remain configurable and may later use a
-  simpler or smaller model than the user-facing reply preset.
+- Memory extraction is configurable and uses a stable model independent
+  from the user-facing reply preset.
 
 ## Problem Statement
 
@@ -145,12 +144,13 @@ due to long-running thought traces.
 
 ### Curated preset registry
 
-Introduce a checked-in backend registry of user-facing model presets.
+The backend maintains a checked-in registry of user-facing model presets
+located in `apps/assistant-backend/src/assistant/config/model_presets.py`.
 
-The initial implementation can use a Python module or JSON file in the
-repository.
+The implementation uses a Python-based registry for type-safe
+configuration and ease of integration.
 
-Each preset should define:
+Each preset defines:
 
 - `id`
 - `label`
@@ -282,10 +282,8 @@ Future behavior:
 
 ## Data Model Implications
 
-We should plan for message-level metadata that records preset usage.
-
-At minimum, we should distinguish between user-message metadata and
-assistant-message metadata.
+Preset usage is recorded in message-level metadata within the existing
+`annotations` field.
 
 On user messages:
 
@@ -297,15 +295,14 @@ On assistant messages:
 - `resolved_model`
 - `reasoning_mode`
 
-Recommended initial approach:
+Standard approach:
 
-- store preset usage in a structured message metadata field
-- avoid adding multiple dedicated columns in the first iteration
+- Store preset usage in the `annotations` JSON field.
+- Avoid adding new dedicated columns in the initial implementation.
 
-This gives us flexibility while we experiment with which fields are
-actually useful to persist.
+This provides flexibility while maintaining a clean schema.
 
-Example shape:
+Example shape in `annotations`:
 
 ```json
 {
@@ -315,15 +312,10 @@ Example shape:
 }
 ```
 
-The exact contents can differ by message role.
+The exact contents differ by message role:
 
-For example:
-
-- a user message may only need `selected_preset_id`
-- an assistant message may include the resolved model and reasoning mode
-
-We can later promote stable high-value fields such as `preset_id` to
-dedicated columns if querying, indexing, or analytics needs justify it.
+- A user message stores `selected_preset_id`.
+- An assistant message includes the resolved model and reasoning mode.
 
 ## UI Changes
 
@@ -348,14 +340,17 @@ The UI must adapt its composer state when a user switches presets:
 
 ## Reasoning Display Policy
 
-Initial recommendation:
+Policy for handling reasoning traces:
 
-- persist clean final assistant content as the canonical message body
-- do not include prior reasoning traces in normal conversation history
-- treat reasoning as optional metadata for display or debugging
+- Persist clean final assistant content as the canonical message body.
+- Reasoning traces are stored as structured metadata in `annotations`.
+- **Do not** include reasoning traces in conversation history for future
+  turns to avoid context contamination.
+- Reasoning traces are treated as optional metadata for display or
+  debugging.
 
-This avoids contaminating future turns and memory extraction with raw
-thought traces.
+This ensures that the main dialogue remains focused and that memory
+extraction logic is not confused by internal reasoning steps.
 
 ## Rollout Plan
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -359,57 +359,77 @@ thought traces.
 
 ## Rollout Plan
 
-### Phase 1
+### Phase 1: Preset Registry & Registry API
 
-Create the preset registry and backend preset API.
+Deliver a testable backend registry and the endpoint for the UI to consume.
 
-Deliverables:
+- **Deliverables:**
+  - `ModelPreset` Pydantic model and registry configuration (JSON or Python).
+  - Registry loader service.
+  - `GET /api/v1/model-presets` endpoint.
+  - Unit tests for registry loading and API contract.
 
-- checked-in preset config
-- preset registry loader
-- `GET /api/v1/model-presets`
+### Phase 2: Backend Payload & Persistence Support
 
-### Phase 2
+Add the ability for the backend to receive and persist `preset_id` without
+changing existing LLM behavior yet.
 
-Add per-message preset selection end to end.
+- **Deliverables:**
+  - Update `CreateMessageRequest` and `CreateConversationWithMessageRequest`
+    to include `preset_id`.
+  - Update `Message` SQL model (metadata/annotations) to store the selected preset.
+  - Update `ConversationService` to extract and persist the preset ID.
+  - Tests for message creation with/without preset IDs.
 
-Deliverables:
+### Phase 3: Frontend Model Selector
 
-- frontend dropdown selector
-- request payload updates
-- backend handling of preset id per message
-- persistence of preset metadata
+Implement the UI for selecting presets and passing the ID to the backend.
 
-### Phase 3
+- **Deliverables:**
+  - Frontend API client updates.
+  - Dropdown component near the message composer.
+  - Logic to remember the last-selected preset.
+  - Handling of capability transitions (e.g., clearing images if switching to
+    text-only).
 
-Introduce request and response adapter abstractions.
+### Phase 4: Adapter Architecture & Default Adapter
 
-Deliverables:
+Refactor the LLM service to use the Adapter Pattern, preserving current behavior
+as the "Default" strategy.
 
-- adapter interfaces
-- default adapter for current `qwen2.5` behavior
-- first reasoning-capable adapter path
+- **Deliverables:**
+  - `BaseModelAdapter` interface.
+  - `DefaultModelAdapter` (current `qwen2.5` logic).
+  - Refactor `LLMService.complete_messages` to delegate to the resolver/adapter.
+  - Integration tests ensuring zero regression for standard messages.
 
-### Phase 4
+### Phase 5: First Reasoning Preset (Thinking Mode)
 
-Separate extraction preset configuration from user-facing reply preset
-selection.
+Implement the first non-default behavior: a "Thinking" preset.
 
-Deliverables:
+- **Deliverables:**
+  - `ReasoningModelAdapter` with `think` control and reasoning parsing.
+  - Registry update to include a `thinking` preset.
+  - Persistence of reasoning traces into assistant message annotations.
+  - Tests for reasoning extraction and persistence.
 
-- extraction preset config
-- extraction path reads configured preset
-- tests covering extraction independence
+### Phase 6: Separate Extraction Configuration
 
-### Phase 5
+Decouple memory extraction from the user-facing preset.
 
-Experiment with additional presets and model-specific parsing behavior.
+- **Deliverables:**
+  - Registry-driven extraction preset resolver.
+  - Update `extract_and_save_background` to use the configured extraction preset.
+  - Tests verifying extraction consistency regardless of chat preset.
 
-Deliverables:
+### Phase 7: Multimodal (Vision) Support
 
-- Gemma-specific preset support if adopted
-- reasoning visibility decisions in the UI
-- tuning and evaluation notes
+Add the capability for image-based conversation presets.
+
+- **Deliverables:**
+  - `VisionModelAdapter` for image formatting.
+  - Backend validation for image payloads vs. preset capabilities.
+  - Registry update with a `vision` preset.
 
 ## Testing Strategy
 

--- a/docs/MODEL_PRESETS_PRD.md
+++ b/docs/MODEL_PRESETS_PRD.md
@@ -138,6 +138,24 @@ Each preset should define:
 - `show_reasoning_in_ui`
 - `memory_extraction_preset`
 
+Field intent:
+
+- `capabilities`
+  - a structured description of what the preset can support, such as
+    reasoning, tools, or vision
+  - used by the backend to validate behavior and by the UI to decide
+    whether optional affordances should appear
+- `request_strategy`
+  - a stable identifier for the request adapter behavior used to build
+    prompts and reasoning controls for this preset
+  - example values might look like `default_chat`,
+    `ollama_native_think`, or `gemma_think_token`
+- `response_strategy`
+  - a stable identifier for the response adapter behavior used to parse
+    assistant output for this preset
+  - example values might look like `plain_content`,
+    `ollama_thinking_field`, or `gemma_tag_stripping`
+
 Example conceptual presets:
 
 - `qwen-quick`
@@ -242,11 +260,18 @@ Future behavior:
 
 We should plan for message-level metadata that records preset usage.
 
-At minimum, we likely need assistant and or user message metadata for:
+At minimum, we should distinguish between user-message metadata and
+assistant-message metadata.
 
-- selected preset id
-- resolved model id
-- reasoning mode
+On user messages:
+
+- `selected_preset_id`
+
+On assistant messages:
+
+- `selected_preset_id`
+- `resolved_model`
+- `reasoning_mode`
 
 Recommended initial approach:
 
@@ -265,6 +290,13 @@ Example shape:
   "reasoning_mode": "thinking"
 }
 ```
+
+The exact contents can differ by message role.
+
+For example:
+
+- a user message may only need `selected_preset_id`
+- an assistant message may include the resolved model and reasoning mode
 
 We can later promote stable high-value fields such as `preset_id` to
 dedicated columns if querying, indexing, or analytics needs justify it.


### PR DESCRIPTION
## Summary
- add a PRD and implementation plan for curated per-message model presets
- define the preset registry, preset API, adapter layer, and extraction-model direction
- capture rollout phases, likely touched areas, and open questions for discussion

## Validation
- skipped frontend/backend validation suites because this is a docs-only change and AGENTS.md says app-specific checks are not required for docs-only work