### PR TITLE
docs: Streaming Responses PRD and design

### DIFF
--- a/apps/assistant-backend/src/assistant/models/annotations.py
+++ b/apps/assistant-backend/src/assistant/models/annotations.py
@@ -44,6 +44,9 @@ class FailureAnnotation(BaseModel):
 
 
 class AssistantAnnotations(BaseModel):
+    thought: str | None = Field(
+        None, description='The reasoning trace or chain of thought'
+    )
     sources: list[SourceAnnotation] = Field(default_factory=list)
     tools: list[ToolAnnotation] = Field(default_factory=list)
     memory_hits: list[MemoryHitAnnotation] = Field(default_factory=list)

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -913,6 +913,7 @@ class ConversationService:
 
         # Merge: preserve all existing fields, update only memory_saved
         enriched_annotations = AssistantAnnotations(
+            thought=current_annotations.thought,  # PRESERVE: reasoning trace
             sources=current_annotations.sources,
             tools=current_annotations.tools,
             memory_hits=current_annotations.memory_hits,

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -55,9 +55,12 @@ Initially, we may stream the reasoning/content until a tool call is
 identified, execute the tool, and then continue streaming the next turn.
 
 ### Persistence happens at the end
-To maintain a consistent history, messages should be saved to the
-canonical Postgres database only after the stream has successfully
-finished. Partial/interrupted streams should be handled gracefully.
+To maintain a consistent history, messages are saved to the canonical Postgres
+database only after the stream has successfully finished.
+- **Reasoning Persistence:** The full reasoning trace (if generated) is persisted
+  in the `thought` field within the message's `annotations` JSON object.
+- **Error Handling:** Partial/interrupted streams result in an assistant message
+  with an `error` field and any content received before the interruption.
 
 ### Streaming reasoning vs. content
 For models that emit reasoning traces (like DeepSeek-R1 or Gemma thinking),

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -1,0 +1,220 @@
+# Streaming Responses PRD
+
+## Summary
+
+This document defines the implementation plan for real-time streaming
+responses in Family Assistant.
+
+The product goal is to eliminate long wait times for assistant replies,
+especially for reasoning-heavy or complex models, by delivering content to
+the user as it is generated.
+
+## Product Goals
+
+- Support real-time streaming of assistant responses in the chat UI.
+- Use Server-Sent Events (SSE) for efficient, one-way streaming from
+  backend to frontend.
+- Maintain support for tool calling and background memory extraction
+  within the streaming flow.
+- Provide a responsive UI that handles partial content, thought traces,
+  and final completion states.
+- Ensure messages are correctly persisted to Postgres once the stream is
+  complete.
+
+## Non-Goals
+
+- Implementing full bidirectional WebSockets (not needed for this use
+  case).
+- Refactoring the entire database schema (streaming metadata can live in
+  the existing `annotations` or metadata fields).
+- Supporting multi-user collaborative editing of the same stream.
+
+## Problem Statement
+
+The current backend is entirely non-streaming. When a user sends a message:
+1. The backend makes a blocking call to the LLM.
+2. The LLM generates the full response (often taking 10-60+ seconds).
+3. The backend returns the final result.
+4. The user sees a loading spinner for the entire duration.
+
+This leads to a poor user experience, especially with local models or
+reasoning modes (like "Thinking" mode) where the time-to-first-token is
+high.
+
+## Key Technical Observations
+
+### Server-Sent Events (SSE) are the right fit
+Since the assistant response is a one-way stream of data from the server
+to the client, SSE is simpler to implement and maintain than WebSockets
+while being more efficient than long polling.
+
+### Tool calls must be handled carefully
+Streaming complicates tool-calling loops. The system must decide when to
+emit tokens to the user and when to pause for tool execution.
+Initially, we may stream the reasoning/content until a tool call is
+identified, execute the tool, and then continue streaming the next turn.
+
+### Persistence happens at the end
+To maintain a consistent history, messages should be saved to the
+canonical Postgres database only after the stream has successfully
+finished. Partial/interrupted streams should be handled gracefully.
+
+### Streaming reasoning vs. content
+For models that emit reasoning traces (like DeepSeek-R1 or Gemma thinking),
+the stream should distinguish between thought tokens and final content
+tokens so the UI can render them differently.
+
+## Proposed Solution
+
+### Backend: Streaming LLM Service
+Refactor `LLMService` to support a streaming mode that yields tokens from
+the Ollama/OpenAI API.
+
+### Backend: Streaming Conversation Service
+Introduce a new endpoint or update existing ones to return a
+`StreamingResponse` (FastAPI).
+
+New endpoint structure (conceptual):
+```text
+POST /api/v1/conversations/{id}/messages/stream
+```
+
+### Backend: Event Protocol
+Define a clear SSE event protocol:
+- `token`: Partial content or reasoning token.
+- `tool_call`: Metadata about a tool being executed.
+- `done`: Final completion metadata, including full content for
+  persistence.
+- `error`: Terminal failure information.
+
+### Frontend: Streaming API Client
+Update the frontend API client (e.g., using `fetch` with `ReadableStream`)
+to consume the SSE stream and update the application state in real-time.
+
+### Frontend: UI Feedback
+Update `Chat.tsx` and `ConversationsChat.tsx` to:
+- Show an active streaming state for the latest assistant message.
+- Render content as it arrives.
+- Distinguish between reasoning traces and final content.
+
+## Architecture Changes
+
+### New concepts
+- `StreamingLLMService`
+- `SSEProtocol`
+- `StreamingState` (Frontend)
+
+### Existing areas touched
+- `apps/assistant-backend/src/assistant/services/llm_service.py`
+- `apps/assistant-backend/src/assistant/services/conversation_service.py`
+- `apps/assistant-backend/src/assistant/routers/chat.py`
+- `apps/assistant-ui/src/lib/api.ts`
+- `apps/assistant-ui/src/components/Chat.tsx`
+
+## Rollout Plan
+
+### Phase 1: Streaming Infrastructure (SSE)
+- Implement a basic SSE endpoint that streams a "Hello World" or hardcoded
+  message.
+- Update the frontend to consume and display this stream.
+
+### Phase 2: Streaming LLM Service
+- Refactor `LLMService.complete_messages` or add a streaming variant to
+  proxy tokens from Ollama.
+- Handle basic text-only streaming.
+
+### Phase 3: Streaming Persistence
+- Ensure the full message is persisted to Postgres once the stream ends.
+- Update `ConversationService` to handle the transition from transient
+  streaming tokens to persisted DB rows.
+
+### Phase 4: Streaming Tool Calls & Reasoning
+- Add support for streaming tool call markers and reasoning traces.
+- Update the UI to render reasoning in a distinct area.
+- Integrate with existing `AssistantAnnotationService`.
+
+## Testing Strategy
+
+- **Backend:** Mock LLM streams and verify SSE event sequence.
+- **Backend:** Test persistence of interrupted streams.
+- **Frontend:** Verify UI responsiveness during streaming.
+- **Frontend:** Test reconnection/error handling for dropped streams.
+
+## Open Questions & Proposed Answers
+
+### Endpoint Strategy
+**Question:** Should we use the existing POST endpoint or a new `/stream` path?
+
+**Recommendation:** Use the existing `POST` endpoints (e.g.,
+`/api/v1/conversations/{id}/messages`) and toggle streaming behavior based on a
+`stream: true` field in the request body.
+- **Why:** Keeps the API surface clean. The resource being created (a message) is
+  the same; only the delivery mechanism changes.
+
+### Handling "Thinking" Tokens
+**Question:** How should we handle "Thinking" tokens from Ollama vs. manual tags in the stream?
+
+**Recommendation:** The SSE protocol should include a specific `thought` event
+type.
+- **Implementation:** For models like DeepSeek-R1, the backend will detect the
+  start/end of reasoning blocks (either via native fields or tags) and emit
+  them as `thought` events. Standard content will be emitted as `token` events.
+
+### Cancellation Support
+**Question:** Do we need to support stopping/canceling an active stream from the UI?
+
+**Recommendation:** Yes.
+- **Implementation:** If the frontend closes the SSE connection, the backend
+  should detect the `ClientDisconnect` (standard in FastAPI/Starlette) and
+  cancel the underlying LLM request to save local compute resources.
+
+## Technical Flow & Wiring
+
+### End-to-End Diagram
+
+```mermaid
+sequenceDiagram
+    participant UI as Frontend (React)
+    participant BE as Backend (FastAPI)
+    participant LLM as LLM Service
+    participant OLL as Ollama API
+
+    UI->>BE: POST /api/v1/conversations/... (stream: true)
+    BE->>BE: Persist user message
+    BE->>LLM: stream_chat_completion(...)
+    LLM->>OLL: POST /v1/chat/completions (stream: true)
+    
+    loop Stream Chunks
+        OLL-->>LLM: SSE Chunk (OpenAI Format)
+        LLM-->>BE: Yield Token/Thought
+        BE-->>UI: SSE Event (App Protocol)
+        UI->>UI: Append to transient state
+    end
+
+    BE->>BE: Persist full assistant message
+    BE->>BE: Trigger background extraction
+    BE-->>UI: [DONE] Event
+```
+
+### Protocol Details
+
+1.  **Ollama Support:** Ollama supports streaming natively via its OpenAI-compatible
+    `/v1/chat/completions` endpoint. By setting `stream: true`, Ollama emits standard
+    SSE chunks (`data: { "choices": [...] }`).
+2.  **Backend Passthrough:** The `LLMService` uses `httpx.AsyncClient.stream()` to
+    consume Ollama's stream. It parses these chunks and yields them to the
+    `ConversationService`.
+3.  **App-Level SSE:** The `ConversationService` wraps the generator in a FastAPI
+    `StreamingResponse`. It translates raw LLM chunks into our structured app
+    events:
+    - `thought`: For reasoning tokens (detected via `<think>` tags or Ollama fields).
+    - `token`: For user-facing content.
+    - `done`: Final metadata and persistence confirmation.
+
+## References
+
+- **Ollama OpenAI Compatibility:** [https://ollama.com/blog/openai-compatibility](https://ollama.com/blog/openai-compatibility)
+- **FastAPI StreamingResponse:** [https://fastapi.tiangolo.com/advanced/custom-response/#streamingresponse](https://fastapi.tiangolo.com/advanced/custom-response/#streamingresponse)
+- **MDN: Using Server-Sent Events:** [https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)
+- **HTTPX Streaming:** [https://www.python-httpx.org/advanced/streaming/](https://www.python-httpx.org/advanced/streaming/)
+- **Ollama API Documentation (Native NDJSON):** [https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion)

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -116,30 +116,29 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
 
 ## Rollout Plan
 
-### Phase 1: Shared Streaming Infrastructure
-- **PR 1.1:** Add `ChatCompletionStreamResponse` and chunk-parsing models in `models/llm.py`.
-- **PR 1.2:** Implement an `SSEEncoder` utility to format payloads into `data: ...\n\n` strings.
-- **PR 1.3:** Create a mock streaming endpoint `GET /api/v1/debug/stream` for pipe testing.
+### Phase 1: Models & Parsing (Backend)
+- **PR 1:** Add `ChatCompletionStreamResponse` models and the `StreamParser` utility
+  to handle reasoning/content detection.
 
-### Phase 2: Frontend Foundation
-- **PR 2.1:** Implement a streaming `fetch` consumer in `lib/api.ts` that handles the SSE protocol.
-- **PR 2.2:** Update `Chat.tsx` to manage "transient" streaming state for the latest message.
+### Phase 2: LLM Service Refactor (Backend)
+- **PR 2:** Refactor `LLMService` to unify request construction and implement the
+  `stream_messages` generator.
 
-### Phase 3: LLM Service Streaming
-- **PR 3.1:** Implement `LLMService.stream_messages()` using `httpx.AsyncClient.stream`.
-- **PR 3.2:** Add unit tests with mock streaming LLM responses.
+### Phase 3: SSE Infrastructure (Infrastructure)
+- **PR 3:** Implement the `SSEEncoder` utility and a debug endpoint to verify the
+  delivery pipeline.
 
-### Phase 4: End-to-End Streaming (Base)
-- **PR 4.1:** Implement `add_message_and_stream_response()` in `ConversationService` (yields tokens, persists user message).
-- **PR 4.2:** Update router to return FastAPI `StreamingResponse` when `stream: true` is requested.
+### Phase 4: Streaming Hook (Frontend)
+- **PR 4:** Implement the `useStreamingConversation` custom hook to encapsulate SSE
+  consumption and transient state management.
 
-### Phase 5: Persistence & Finalization
-- **PR 5.1:** Add logic to persist the full accumulated assistant message to Postgres after the stream completes.
-- **PR 5.2:** Ensure background extraction is triggered correctly post-persistence.
+### Phase 5: Conversation Lifecycle (Backend)
+- **PR 5:** Implement the full streaming lifecycle in `ConversationService`,
+  including immediate user message persistence and deferred assistant persistence.
 
-### Phase 6: Advanced Logic (Reasoning & Tools)
-- **PR 6.1:** Add support for the `thought` event type and update UI for reasoning display.
-- **PR 6.2:** Handle streaming transitions through multi-round tool-calling loops.
+### Phase 6: UI Integration (Frontend)
+- **PR 6:** Integrate the streaming hook into the main Chat UI and add styling for
+  thought traces.
 
 ## Testing Strategy
 
@@ -196,28 +195,31 @@ sequenceDiagram
         OLL-->>LLM: SSE Chunk (OpenAI Format)
         LLM-->>BE: Yield Token/Thought
         BE-->>UI: SSE Event (App Protocol)
-        UI->>UI: Append to transient state
+        UI->>UI: Append to transient state via hook
     end
 
     BE->>BE: Persist full assistant message
     BE->>BE: Trigger background extraction
-    BE-->>UI: [DONE] Event
+    BE-->>UI: [DONE] Event (includes persistence confirmation)
 ```
 
 ### Protocol Details
 
 1.  **Ollama Support:** Ollama supports streaming natively via its OpenAI-compatible
     `/v1/chat/completions` endpoint. By setting `stream: true`, Ollama emits standard
-    SSE chunks (`data: { "choices": [...] }`).
-2.  **Backend Passthrough:** The `LLMService` uses `httpx.AsyncClient.stream()` to
-    consume Ollama's stream. It parses these chunks and yields them to the
-    `ConversationService`.
+    SSE chunks.
+2.  **Backend Passthrough:**
+    - **LLMService:** Uses `httpx.AsyncClient.stream()` to consume Ollama's stream.
+    - **StreamParser:** A dedicated utility parses raw chunks into `thought` vs
+      `content` segments, shielding the transport layer from model-specific
+      tags/fields.
 3.  **App-Level SSE:** The `ConversationService` wraps the generator in a FastAPI
     `StreamingResponse`. It translates raw LLM chunks into our structured app
     events:
-    - `thought`: For reasoning tokens (detected via `<think>` tags or Ollama fields).
+    - `thought`: For reasoning tokens.
     - `token`: For user-facing content.
-    - `done`: Final metadata and persistence confirmation.
+    - `error`: Typed error detail for mid-stream failures.
+    - `done`: Final metadata, complete content, and persistence confirmation.
 
 ## References
 

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -116,25 +116,30 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
 
 ## Rollout Plan
 
-### Phase 1: Streaming Infrastructure (SSE)
-- Implement a basic SSE endpoint that streams a "Hello World" or hardcoded
-  message.
-- Update the frontend to consume and display this stream.
+### Phase 1: Shared Streaming Infrastructure
+- **PR 1.1:** Add `ChatCompletionStreamResponse` and chunk-parsing models in `models/llm.py`.
+- **PR 1.2:** Implement an `SSEEncoder` utility to format payloads into `data: ...\n\n` strings.
+- **PR 1.3:** Create a mock streaming endpoint `GET /api/v1/debug/stream` for pipe testing.
 
-### Phase 2: Streaming LLM Service
-- Refactor `LLMService.complete_messages` or add a streaming variant to
-  proxy tokens from Ollama.
-- Handle basic text-only streaming.
+### Phase 2: Frontend Foundation
+- **PR 2.1:** Implement a streaming `fetch` consumer in `lib/api.ts` that handles the SSE protocol.
+- **PR 2.2:** Update `Chat.tsx` to manage "transient" streaming state for the latest message.
 
-### Phase 3: Streaming Persistence
-- Ensure the full message is persisted to Postgres once the stream ends.
-- Update `ConversationService` to handle the transition from transient
-  streaming tokens to persisted DB rows.
+### Phase 3: LLM Service Streaming
+- **PR 3.1:** Implement `LLMService.stream_messages()` using `httpx.AsyncClient.stream`.
+- **PR 3.2:** Add unit tests with mock streaming LLM responses.
 
-### Phase 4: Streaming Tool Calls & Reasoning
-- Add support for streaming tool call markers and reasoning traces.
-- Update the UI to render reasoning in a distinct area.
-- Integrate with existing `AssistantAnnotationService`.
+### Phase 4: End-to-End Streaming (Base)
+- **PR 4.1:** Implement `add_message_and_stream_response()` in `ConversationService` (yields tokens, persists user message).
+- **PR 4.2:** Update router to return FastAPI `StreamingResponse` when `stream: true` is requested.
+
+### Phase 5: Persistence & Finalization
+- **PR 5.1:** Add logic to persist the full accumulated assistant message to Postgres after the stream completes.
+- **PR 5.2:** Ensure background extraction is triggered correctly post-persistence.
+
+### Phase 6: Advanced Logic (Reasoning & Tools)
+- **PR 6.1:** Add support for the `thought` event type and update UI for reasoning display.
+- **PR 6.2:** Handle streaming transitions through multi-round tool-calling loops.
 
 ## Testing Strategy
 

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -74,13 +74,12 @@ Refactor `LLMService` to support a streaming mode that yields tokens from
 the Ollama/OpenAI API.
 
 ### Backend: Streaming Conversation Service
-Introduce a new endpoint or update existing ones to return a
-`StreamingResponse` (FastAPI).
+Update existing endpoints to return a `StreamingResponse` (FastAPI) when
+the request body includes `stream: true`.
 
-New endpoint structure (conceptual):
-```text
-POST /api/v1/conversations/{id}/messages/stream
-```
+Affected endpoints:
+- `POST /api/v1/conversations/with-message`
+- `POST /api/v1/conversations/{id}/messages`
 
 ### Backend: Event Protocol
 Define a clear SSE event protocol:

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -54,13 +54,21 @@ emit tokens to the user and when to pause for tool execution.
 Initially, we may stream the reasoning/content until a tool call is
 identified, execute the tool, and then continue streaming the next turn.
 
-### Persistence happens at the end
-To maintain a consistent history, messages are saved to the canonical Postgres
-database only after the stream has successfully finished.
-- **Reasoning Persistence:** The full reasoning trace (if generated) is persisted
-  in the `thought` field within the message's `annotations` JSON object.
-- **Error Handling:** Partial/interrupted streams result in an assistant message
-  with an `error` field and any content received before the interruption.
+### Persistence distinguishes user vs. assistant messages
+To maintain a consistent history while preserving failure recovery semantics,
+the user message is persisted to the canonical Postgres database as soon as
+the request is accepted, while the assistant message is persisted after the
+stream reaches a terminal state.
+- **User Message Persistence:** Persist the user turn immediately so the
+  conversation history is durable even if generation or streaming fails.
+- **Assistant Message Persistence:** Persist the assistant turn when the
+  stream successfully completes, including the final assembled content.
+- **Reasoning Persistence:** The full reasoning trace (if generated) is
+  persisted in the `thought` field within the message's `annotations` JSON
+  object.
+- **Error Handling:** If the stream is interrupted after assistant output has
+  begun, persist an assistant message in a terminal error state with an
+  `error` field and any content received before the interruption.
 
 ### Streaming reasoning vs. content
 For models that emit reasoning traces (like DeepSeek-R1 or Gemma thinking),
@@ -82,12 +90,19 @@ Affected endpoints:
 - `POST /api/v1/conversations/{id}/messages`
 
 ### Backend: Event Protocol
-Define a clear SSE event protocol:
-- `token`: Partial content or reasoning token.
+Define the authoritative SSE event protocol for frontend and backend
+implementations:
+
+- `thought`: Partial reasoning trace token intended for thought-trace UI.
+- `token`: Partial assistant content token intended for the final visible
+  response.
 - `tool_call`: Metadata about a tool being executed.
 - `done`: Final completion metadata, including full content for
-  persistence.
+  persistence and the finalized message ID.
 - `error`: Terminal failure information.
+
+Reasoning traces must be emitted as `thought` events, while user-visible
+response text must be emitted as `token` events.
 
 ### Frontend: Streaming API Client
 Update the frontend API client (e.g., using `fetch` with `ReadableStream`)


### PR DESCRIPTION
This PR introduces the Streaming Responses PRD and design doc. It includes the technical flow for Ollama streaming, a detailed rollout plan for incremental implementation, and updates to the annotation model to support reasoning traces.