### PR TITLE
feat(backend): implement stream_messages generator in LLMService (Phase 2)

### DIFF
--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -1,3 +1,6 @@
+import logging
+from typing import AsyncGenerator
+
 import httpx
 import pydantic
 
@@ -7,7 +10,11 @@ from assistant.models.llm import (
     LLMCompletionError,
     LLMCompletionErrorKind,
     LLMCompletionResult,
+    StreamParserOutput,
 )
+from assistant.services.stream_parser import StreamParser
+
+logger = logging.getLogger(__name__)
 
 
 class LLMService:
@@ -26,6 +33,28 @@ class LLMService:
     async def aclose(self) -> None:
         """Close the underlying HTTP client and release network resources."""
         await self.client.aclose()
+
+    def _build_request_body(
+        self,
+        messages: list[dict],
+        model: str,
+        temperature: float,
+        max_tokens: int | None,
+        stream: bool,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
+    ) -> dict:
+        """Construct the OpenAI-compatible request body."""
+        request = CreateChatCompletionRequest(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=stream,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        return request.model_dump(exclude_none=True)
 
     async def complete_messages(
         self,
@@ -62,9 +91,9 @@ class LLMService:
             LLMCompletionError: On any failure (timeout, unreachable,
                 backend error, or invalid response)
         """
-        request_body = CreateChatCompletionRequest(
-            model=model,
+        request_body = self._build_request_body(
             messages=messages,
+            model=model,
             temperature=temperature,
             max_tokens=max_tokens,
             stream=False,
@@ -75,7 +104,7 @@ class LLMService:
         try:
             response = await self.client.post(
                 f'{self.base_url}/v1/chat/completions',
-                json=request_body.model_dump(exclude_none=True),
+                json=request_body,
             )
             response.raise_for_status()
         except httpx.TimeoutException as exc:
@@ -106,7 +135,7 @@ class LLMService:
 
         # Validate response shape
         try:
-            response = CreateChatCompletionResponse.model_validate(
+            response_obj = CreateChatCompletionResponse.model_validate(
                 response_dict
             )
         except pydantic.ValidationError as exc:
@@ -116,19 +145,116 @@ class LLMService:
             ) from exc
 
         # Extract first choice
-        if not response.choices:
+        if not response_obj.choices:
             raise LLMCompletionError(
                 kind=LLMCompletionErrorKind.invalid_response,
                 message='LLM backend did not return any choices',
             )
 
-        choice = response.choices[0]
+        choice = response_obj.choices[0]
         return LLMCompletionResult(
             content=choice.message.content or '',
-            model=response.model,
-            prompt_tokens=response.usage.prompt_tokens,
-            completion_tokens=response.usage.completion_tokens,
-            total_tokens=response.usage.total_tokens,
+            model=response_obj.model,
+            prompt_tokens=response_obj.usage.prompt_tokens,
+            completion_tokens=response_obj.usage.completion_tokens,
+            total_tokens=response_obj.usage.total_tokens,
             tool_calls=choice.message.tool_calls,
             finish_reason=choice.finish_reason,
         )
+
+    async def stream_messages(
+        self,
+        *,
+        messages: list[dict],
+        model: str,
+        temperature: float,
+        max_tokens: int | None,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
+    ) -> AsyncGenerator[StreamParserOutput, None]:
+        """Execute a streaming chat completion request.
+
+        This is the streaming equivalent of complete_messages. It yields
+        incremental parser outputs including thought, tokens, and tool calls.
+
+        Args:
+            messages: List of messages including system prompt
+            model: Model identifier
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+            tools: Optional list of tool definitions
+            tool_choice: Optional tool choice specification
+
+        Yields:
+            StreamParserOutput for each chunk of the response
+
+        Raises:
+            LLMCompletionError: On transport or backend errors
+        """
+        request_body = self._build_request_body(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+
+        parser = StreamParser()
+
+        try:
+            async with self.client.stream(
+                'POST',
+                f'{self.base_url}/v1/chat/completions',
+                json=request_body,
+            ) as response:
+                if response.status_code != 200:
+                    # Drain response to get error message if possible
+                    await response.aread()
+                    raise LLMCompletionError(
+                        kind=LLMCompletionErrorKind.backend_error,
+                        message='LLM backend returned an error',
+                        backend_status_code=response.status_code,
+                    )
+
+                async for line in response.aiter_lines():
+                    if not line.startswith('data: '):
+                        continue
+
+                    data = line[6:].strip()
+                    if data == '[DONE]':
+                        break
+
+                    try:
+                        chunk_dict = pydantic.TypeAdapter(dict).validate_json(
+                            data
+                        )
+                        output = parser.parse_chunk(chunk_dict)
+                        yield output
+                    except Exception as exc:
+                        # Skip malformed chunks in the stream
+                        logger.debug(
+                            'Skipping malformed chunk in stream: %s',
+                            data,
+                            exc_info=exc,
+                        )
+                        continue
+
+        except httpx.TimeoutException as exc:
+            raise LLMCompletionError(
+                kind=LLMCompletionErrorKind.timeout,
+                message='LLM request timed out',
+            ) from exc
+        except httpx.ConnectError as exc:
+            raise LLMCompletionError(
+                kind=LLMCompletionErrorKind.unreachable,
+                message='Failed to reach LLM backend',
+            ) from exc
+        except httpx.HTTPError as exc:
+            if isinstance(exc, LLMCompletionError):
+                raise
+            raise LLMCompletionError(
+                kind=LLMCompletionErrorKind.backend_error,
+                message=f'LLM transport error: {exc}',
+            ) from exc

--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import AsyncGenerator
 
@@ -227,9 +228,7 @@ class LLMService:
                         break
 
                     try:
-                        chunk_dict = pydantic.TypeAdapter(dict).validate_json(
-                            data
-                        )
+                        chunk_dict = json.loads(data)
                         output = parser.parse_chunk(chunk_dict)
                         yield output
                     except Exception as exc:
@@ -252,8 +251,6 @@ class LLMService:
                 message='Failed to reach LLM backend',
             ) from exc
         except httpx.HTTPError as exc:
-            if isinstance(exc, LLMCompletionError):
-                raise
             raise LLMCompletionError(
                 kind=LLMCompletionErrorKind.backend_error,
                 message=f'LLM transport error: {exc}',

--- a/apps/assistant-backend/tests/services/test_llm_service.py
+++ b/apps/assistant-backend/tests/services/test_llm_service.py
@@ -330,3 +330,152 @@ async def test_complete_messages_invalid_json():
         assert 'unexpected response shape' in exc_info.value.message.lower()
     finally:
         await service.aclose()
+
+
+# Tests for stream_messages (streaming LLM completion seam)
+
+
+async def test_stream_messages_success():
+    """It yields StreamParserOutput objects for each chunk."""
+    messages = [{'role': 'user', 'content': 'Hello'}]
+
+    # Mock SSE stream data
+    chunks = [
+        {
+            'id': '1',
+            'object': 'chat.completion.chunk',
+            'created': 1,
+            'model': 'test',
+            'choices': [{'index': 0, 'delta': {'role': 'assistant'}, 'finish_reason': None}],
+        },
+        {
+            'id': '2',
+            'object': 'chat.completion.chunk',
+            'created': 2,
+            'model': 'test',
+            'choices': [{'index': 0, 'delta': {'content': 'Hi'}, 'finish_reason': None}],
+        },
+        {
+            'id': '3',
+            'object': 'chat.completion.chunk',
+            'created': 3,
+            'model': 'test',
+            'choices': [{'index': 0, 'delta': {'content': ' there'}, 'finish_reason': 'stop'}],
+        },
+    ]
+
+    sse_content = ''.join([f'data: {json.dumps(c)}\n\n' for c in chunks])
+    sse_content += 'data: [DONE]\n\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == '/v1/chat/completions'
+        payload = json.loads(request.content)
+        assert payload['stream'] is True
+        return httpx.Response(
+            200,
+            content=sse_content.encode('utf-8'),
+            headers={'content-type': 'text/event-stream'},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url='http://test')
+    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    outputs = []
+    try:
+        async for output in service.stream_messages(
+            messages=messages,
+            model='test-model',
+            temperature=0.7,
+            max_tokens=128,
+        ):
+            outputs.append(output)
+    finally:
+        await service.aclose()
+
+    assert len(outputs) == 3
+    assert outputs[0].model == 'test'
+    assert outputs[1].token == 'Hi'
+    assert outputs[2].token == ' there'
+    assert outputs[2].finish_reason == 'stop'
+
+
+async def test_stream_messages_timeout():
+    """It raises LLMCompletionError on stream timeout."""
+    from unittest.mock import MagicMock
+    client = httpx.AsyncClient(base_url='http://test')
+    # Mock stream to return an async context manager that raises on __aenter__
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.TimeoutException('Timeout'))
+    client.stream = MagicMock(return_value=mock_ctx)
+    
+    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    try:
+        with pytest.raises(LLMCompletionError) as exc_info:
+            async for _ in service.stream_messages(
+                messages=[],
+                model='test',
+                temperature=0.7,
+                max_tokens=100,
+            ):
+                pass
+
+        assert exc_info.value.kind == LLMCompletionErrorKind.timeout
+        assert exc_info.value.message == 'LLM request timed out'
+    finally:
+        await service.aclose()
+
+
+async def test_stream_messages_unreachable():
+    """It raises LLMCompletionError when backend is unreachable."""
+    from unittest.mock import MagicMock
+    client = httpx.AsyncClient(base_url='http://test')
+    # Mock stream to return an async context manager that raises on __aenter__
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.ConnectError('Connection failed'))
+    client.stream = MagicMock(return_value=mock_ctx)
+    
+    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    try:
+        with pytest.raises(LLMCompletionError) as exc_info:
+            async for _ in service.stream_messages(
+                messages=[],
+                model='test',
+                temperature=0.7,
+                max_tokens=100,
+            ):
+                pass
+
+        assert exc_info.value.kind == LLMCompletionErrorKind.unreachable
+        assert exc_info.value.message == 'Failed to reach LLM backend'
+    finally:
+        await service.aclose()
+
+
+async def test_stream_messages_backend_error():
+    """It raises LLMCompletionError on non-200 response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, content=b'Internal Server Error', request=request)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url='http://test')
+    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    try:
+        with pytest.raises(LLMCompletionError) as exc_info:
+            async for _ in service.stream_messages(
+                messages=[],
+                model='test',
+                temperature=0.7,
+                max_tokens=100,
+            ):
+                pass
+
+        assert exc_info.value.kind == LLMCompletionErrorKind.backend_error
+        assert exc_info.value.backend_status_code == 500
+    finally:
+        await service.aclose()

--- a/apps/assistant-backend/tests/services/test_llm_service.py
+++ b/apps/assistant-backend/tests/services/test_llm_service.py
@@ -346,21 +346,35 @@ async def test_stream_messages_success():
             'object': 'chat.completion.chunk',
             'created': 1,
             'model': 'test',
-            'choices': [{'index': 0, 'delta': {'role': 'assistant'}, 'finish_reason': None}],
+            'choices': [
+                {
+                    'index': 0,
+                    'delta': {'role': 'assistant'},
+                    'finish_reason': None,
+                }
+            ],
         },
         {
             'id': '2',
             'object': 'chat.completion.chunk',
             'created': 2,
             'model': 'test',
-            'choices': [{'index': 0, 'delta': {'content': 'Hi'}, 'finish_reason': None}],
+            'choices': [
+                {'index': 0, 'delta': {'content': 'Hi'}, 'finish_reason': None}
+            ],
         },
         {
             'id': '3',
             'object': 'chat.completion.chunk',
             'created': 3,
             'model': 'test',
-            'choices': [{'index': 0, 'delta': {'content': ' there'}, 'finish_reason': 'stop'}],
+            'choices': [
+                {
+                    'index': 0,
+                    'delta': {'content': ' there'},
+                    'finish_reason': 'stop',
+                }
+            ],
         },
     ]
 
@@ -380,7 +394,9 @@ async def test_stream_messages_success():
 
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport, base_url='http://test')
-    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
 
     outputs = []
     try:
@@ -404,13 +420,18 @@ async def test_stream_messages_success():
 async def test_stream_messages_timeout():
     """It raises LLMCompletionError on stream timeout."""
     from unittest.mock import MagicMock
+
     client = httpx.AsyncClient(base_url='http://test')
     # Mock stream to return an async context manager that raises on __aenter__
     mock_ctx = MagicMock()
-    mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.TimeoutException('Timeout'))
+    mock_ctx.__aenter__ = AsyncMock(
+        side_effect=httpx.TimeoutException('Timeout')
+    )
     client.stream = MagicMock(return_value=mock_ctx)
-    
-    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
 
     try:
         with pytest.raises(LLMCompletionError) as exc_info:
@@ -431,13 +452,18 @@ async def test_stream_messages_timeout():
 async def test_stream_messages_unreachable():
     """It raises LLMCompletionError when backend is unreachable."""
     from unittest.mock import MagicMock
+
     client = httpx.AsyncClient(base_url='http://test')
     # Mock stream to return an async context manager that raises on __aenter__
     mock_ctx = MagicMock()
-    mock_ctx.__aenter__ = AsyncMock(side_effect=httpx.ConnectError('Connection failed'))
+    mock_ctx.__aenter__ = AsyncMock(
+        side_effect=httpx.ConnectError('Connection failed')
+    )
     client.stream = MagicMock(return_value=mock_ctx)
-    
-    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
 
     try:
         with pytest.raises(LLMCompletionError) as exc_info:
@@ -459,11 +485,15 @@ async def test_stream_messages_backend_error():
     """It raises LLMCompletionError on non-200 response."""
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(500, content=b'Internal Server Error', request=request)
+        return httpx.Response(
+            500, content=b'Internal Server Error', request=request
+        )
 
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport, base_url='http://test')
-    service = LLMService(base_url='http://test', timeout_seconds=5, client=client)
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
 
     try:
         with pytest.raises(LLMCompletionError) as exc_info:


### PR DESCRIPTION
Refactor LLMService to unify request construction and implement the stream_messages async generator for SSE streaming support.

Key changes:
- Unified request construction via `_build_request_body`
- Implemented `stream_messages` generator using `httpx.AsyncClient.stream`
- Integrated `StreamParser` for incremental chunk parsing (thought, token, tool calls)
- Comprehensive error handling and mapping to `LLMCompletionError`
- Added debug logging for malformed stream chunks
- Full test coverage for streaming success, timeouts, connectivity, and backend errors

Addresses PR 2 of the [Streaming Responses PRD](docs/STREAMING_RESPONSES_PRD.md).