### PR TITLE
feat(assistant-backend): implement streaming conversation lifecycle persistence

### DIFF
--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import json
 import logging
-from typing import cast
+from typing import AsyncGenerator, cast
 import uuid
 
 from fastapi import BackgroundTasks, HTTPException, status
@@ -25,6 +25,7 @@ from assistant.models.llm import (
     ChatCompletionRequestSystemMessage,
     LLMCompletionError,
     LLMCompletionErrorKind,
+    StreamParserOutput,
     ToolChoice,
 )
 from assistant.models.tool import ToolExecutionResult
@@ -39,6 +40,7 @@ from assistant.services.tool_service import ToolService
 from assistant.services.tools.errors import UnsupportedToolError
 from assistant.services.tools.factory import DisabledToolError
 from assistant.settings import settings
+from assistant.utils.sse import SSEEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -364,6 +366,282 @@ class ConversationService:
             assistant_message=self._message_read(assistant_message),
         )
 
+    async def create_conversation_with_message_stream(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: str,
+        payload: CreateConversationWithMessageRequest,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> AsyncGenerator[str, None]:
+        """Stream assistant response while persisting lifecycle in two phases.
+
+        Phase 1 (immediate): persist conversation + user message.
+        Phase 2 (deferred): persist assistant message only on terminal success,
+        or terminal failure if output has already started.
+        """
+        content = payload.content.strip()
+        if not content:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Message content cannot be empty',
+            )
+
+        conversation = Conversation(
+            user_id=user_id,
+            title=conversation_title_from_first_message(content),
+        )
+        session.add(conversation)
+        await session.flush()
+
+        user_message = Message(
+            conversation_id=conversation.id,
+            role='user',
+            content=content,
+            sequence_number=1,
+        )
+        session.add(user_message)
+        await session.commit()
+        await session.refresh(user_message)
+
+        context_result = (
+            await self.context_assembly.assemble_context_new_conversation(
+                session,
+                user_id=user_id,
+                user_message=content,
+            )
+        )
+
+        async for event in self._stream_assistant_lifecycle(
+            session=session,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            user_message_id=user_message.id,
+            assistant_sequence_number=2,
+            context_messages=context_result.messages,
+            fact_ids=context_result.fact_ids,
+            temperature=payload.temperature,
+            max_tokens=payload.max_tokens,
+            background_tasks=background_tasks,
+        ):
+            yield event
+
+    async def add_message_to_conversation_stream(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: str,
+        conversation_id: uuid.UUID,
+        payload: CreateMessageRequest,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> AsyncGenerator[str, None]:
+        """Stream assistant response for an existing conversation lifecycle."""
+        content = payload.content.strip()
+        if not content:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Message content cannot be empty',
+            )
+
+        await self._get_conversation_for_user(
+            session,
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+
+        existing_messages = await self._get_messages_for_conversation(
+            session,
+            conversation_id=conversation_id,
+        )
+        next_seq = (
+            1
+            if not existing_messages
+            else existing_messages[-1].sequence_number + 1
+        )
+
+        user_message = Message(
+            conversation_id=conversation_id,
+            role='user',
+            content=content,
+            sequence_number=next_seq,
+        )
+        session.add(user_message)
+        await session.commit()
+        await session.refresh(user_message)
+
+        context_result = await self.context_assembly.assemble_context(
+            session,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            new_user_message=None,
+        )
+
+        async for event in self._stream_assistant_lifecycle(
+            session=session,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            user_message_id=user_message.id,
+            assistant_sequence_number=next_seq + 1,
+            context_messages=context_result.messages,
+            fact_ids=context_result.fact_ids,
+            temperature=payload.temperature,
+            max_tokens=payload.max_tokens,
+            background_tasks=background_tasks,
+        ):
+            yield event
+
+    async def _stream_assistant_lifecycle(
+        self,
+        *,
+        session: AsyncSession,
+        user_id: str,
+        conversation_id: uuid.UUID,
+        user_message_id: uuid.UUID,
+        assistant_sequence_number: int,
+        context_messages: list[dict],
+        fact_ids: list[uuid.UUID],
+        temperature: float,
+        max_tokens: int | None,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> AsyncGenerator[str, None]:
+        """Run streaming loop and persist assistant row only at terminal states."""
+        content_parts: list[str] = []
+        thought_parts: list[str] = []
+        model_name: str | None = None
+        usage_payload: dict | None = None
+        stream_started = False
+
+        try:
+            async for output in self._call_llm_chat_completion_stream(
+                messages=context_messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            ):
+                if output.thought:
+                    thought_parts.append(output.thought)
+                    stream_started = True
+                    yield SSEEncoder.encode('thought', output.thought)
+
+                if output.token:
+                    content_parts.append(output.token)
+                    stream_started = True
+                    yield SSEEncoder.encode('token', output.token)
+
+                if output.tool_calls:
+                    stream_started = True
+                    for tool_call in output.tool_calls:
+                        yield SSEEncoder.encode(
+                            'tool_call', tool_call.model_dump()
+                        )
+
+                if output.model:
+                    model_name = output.model
+                if output.usage:
+                    usage_payload = output.usage.model_dump()
+
+        except LLMCompletionError as error:
+            if stream_started:
+                await self._persist_streaming_assistant_message(
+                    session=session,
+                    conversation_id=conversation_id,
+                    sequence_number=assistant_sequence_number,
+                    content=''.join(content_parts)
+                    or 'Unable to generate a response. Please try again.',
+                    thought=''.join(thought_parts) or None,
+                    fact_ids=fact_ids,
+                    error=error,
+                )
+
+            yield SSEEncoder.encode(
+                'error',
+                {
+                    'detail': self.annotation_service.format_error_detail(
+                        error
+                    ),
+                    'kind': error.kind.value,
+                },
+            )
+            return
+
+        assistant_message = await self._persist_streaming_assistant_message(
+            session=session,
+            conversation_id=conversation_id,
+            sequence_number=assistant_sequence_number,
+            content=''.join(content_parts)
+            or 'Unable to generate a response. Please try again.',
+            thought=''.join(thought_parts) or None,
+            fact_ids=fact_ids,
+            error=None,
+        )
+
+        if background_tasks and self.memory_storage:
+            background_tasks.add_task(
+                self.extract_and_save_background,
+                user_id=user_id,
+                conversation_id=conversation_id,
+                assistant_message_id=assistant_message.id,
+                latest_user_message_id=user_message_id,
+            )
+
+        done_payload: dict[str, object] = {
+            'message_id': str(assistant_message.id),
+            'content': assistant_message.content,
+        }
+        if model_name:
+            done_payload['model'] = model_name
+        if usage_payload:
+            done_payload['usage'] = usage_payload
+
+        yield SSEEncoder.encode('done', done_payload)
+
+    async def _persist_streaming_assistant_message(
+        self,
+        *,
+        session: AsyncSession,
+        conversation_id: uuid.UUID,
+        sequence_number: int,
+        content: str,
+        thought: str | None,
+        fact_ids: list[uuid.UUID],
+        error: LLMCompletionError | None,
+    ) -> Message:
+        """Persist an assistant message row for terminal stream completion."""
+        if error:
+            annotations_obj = self.annotation_service.build_failure_annotations(
+                error=error,
+                executed_tools=[],
+                attempted_tool_execution=False,
+            )
+            error_text = self.annotation_service.format_error_detail(error)
+        else:
+            annotations_obj = self.annotation_service.build_success_annotations(
+                executed_tools=[],
+                fact_ids=fact_ids,
+            )
+            error_text = None
+
+        if thought:
+            annotations_obj.thought = thought
+
+        assistant_message = Message(
+            conversation_id=conversation_id,
+            role='assistant',
+            content=content,
+            sequence_number=sequence_number,
+            error=error_text,
+            annotations=annotations_obj.model_dump(),
+        )
+        session.add(assistant_message)
+        await session.execute(
+            update(Conversation)
+            # pyrefly: ignore [bad-argument-type]
+            .where(Conversation.id == conversation_id)
+            .values(updated_at=func.now())
+        )
+        await session.commit()
+        await session.refresh(assistant_message)
+        return assistant_message
+
     async def _get_conversation_for_user(
         self,
         session: AsyncSession,
@@ -542,6 +820,35 @@ class ConversationService:
             executed_tools=executed_tools,
             error=error,
         )
+
+    async def _call_llm_chat_completion_stream(
+        self,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int | None,
+    ) -> AsyncGenerator[StreamParserOutput, None]:
+        """Call streaming completion seam and yield parsed incremental outputs."""
+        system_message = ChatCompletionRequestSystemMessage(
+            role='system', content=SYSTEM_PROMPT
+        )
+        llm_messages = [system_message.model_dump()] + messages
+        available_tools = self.tool_service.get_available_tools()
+        tools = available_tools if available_tools else None
+
+        completion_kwargs = {
+            'messages': llm_messages,
+            'model': settings.llm_model,
+            'temperature': temperature,
+            'max_tokens': max_tokens,
+        }
+        if tools:
+            completion_kwargs['tools'] = [tool.model_dump() for tool in tools]
+            completion_kwargs['tool_choice'] = ToolChoice.auto
+
+        async for output in self.llm_service.stream_messages(
+            **completion_kwargs
+        ):
+            yield output
 
     @staticmethod
     def _conversation_summary(

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,4 +1,6 @@
+import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
 import logging
 from typing import AsyncGenerator, cast
@@ -415,7 +417,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation_id=conversation.id,
+            conversation=conversation,
             user_message_id=user_message.id,
             assistant_sequence_number=2,
             context_messages=context_result.messages,
@@ -443,7 +445,7 @@ class ConversationService:
                 detail='Message content cannot be empty',
             )
 
-        await self._get_conversation_for_user(
+        conversation = await self._get_conversation_for_user(
             session,
             user_id=user_id,
             conversation_id=conversation_id,
@@ -479,7 +481,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation_id=conversation_id,
+            conversation=conversation,
             user_message_id=user_message.id,
             assistant_sequence_number=next_seq + 1,
             context_messages=context_result.messages,
@@ -495,7 +497,7 @@ class ConversationService:
         *,
         session: AsyncSession,
         user_id: str,
-        conversation_id: uuid.UUID,
+        conversation: Conversation,
         user_message_id: uuid.UUID,
         assistant_sequence_number: int,
         context_messages: list[dict],
@@ -543,7 +545,7 @@ class ConversationService:
             if stream_started:
                 await self._persist_streaming_assistant_message(
                     session=session,
-                    conversation_id=conversation_id,
+                    conversation=conversation,
                     sequence_number=assistant_sequence_number,
                     content=''.join(content_parts)
                     or 'Unable to generate a response. Please try again.',
@@ -563,9 +565,27 @@ class ConversationService:
             )
             return
 
+        except asyncio.CancelledError:
+            if stream_started:
+                cancellation_error = LLMCompletionError(
+                    kind=LLMCompletionErrorKind.backend_error,
+                    message='Streaming response interrupted by client disconnect',
+                )
+                await self._persist_streaming_assistant_message(
+                    session=session,
+                    conversation=conversation,
+                    sequence_number=assistant_sequence_number,
+                    content=''.join(content_parts)
+                    or 'Unable to generate a response. Please try again.',
+                    thought=''.join(thought_parts) or None,
+                    fact_ids=fact_ids,
+                    error=cancellation_error,
+                )
+            raise
+
         assistant_message = await self._persist_streaming_assistant_message(
             session=session,
-            conversation_id=conversation_id,
+            conversation=conversation,
             sequence_number=assistant_sequence_number,
             content=''.join(content_parts)
             or 'Unable to generate a response. Please try again.',
@@ -578,14 +598,16 @@ class ConversationService:
             background_tasks.add_task(
                 self.extract_and_save_background,
                 user_id=user_id,
-                conversation_id=conversation_id,
+                conversation_id=conversation.id,
                 assistant_message_id=assistant_message.id,
                 latest_user_message_id=user_message_id,
             )
 
         done_payload: dict[str, object] = {
+            'conversation_id': str(conversation.id),
             'message_id': str(assistant_message.id),
             'content': assistant_message.content,
+            'annotations': assistant_message.annotations,
         }
         if model_name:
             done_payload['model'] = model_name
@@ -598,7 +620,7 @@ class ConversationService:
         self,
         *,
         session: AsyncSession,
-        conversation_id: uuid.UUID,
+        conversation: Conversation,
         sequence_number: int,
         content: str,
         thought: str | None,
@@ -624,7 +646,7 @@ class ConversationService:
             annotations_obj.thought = thought
 
         assistant_message = Message(
-            conversation_id=conversation_id,
+            conversation_id=conversation.id,
             role='assistant',
             content=content,
             sequence_number=sequence_number,
@@ -632,12 +654,7 @@ class ConversationService:
             annotations=annotations_obj.model_dump(),
         )
         session.add(assistant_message)
-        await session.execute(
-            update(Conversation)
-            # pyrefly: ignore [bad-argument-type]
-            .where(Conversation.id == conversation_id)
-            .values(updated_at=func.now())
-        )
+        conversation.updated_at = datetime.now(timezone.utc)
         await session.commit()
         await session.refresh(assistant_message)
         return assistant_message
@@ -832,8 +849,6 @@ class ConversationService:
             role='system', content=SYSTEM_PROMPT
         )
         llm_messages = [system_message.model_dump()] + messages
-        available_tools = self.tool_service.get_available_tools()
-        tools = available_tools if available_tools else None
 
         completion_kwargs = {
             'messages': llm_messages,
@@ -841,13 +856,15 @@ class ConversationService:
             'temperature': temperature,
             'max_tokens': max_tokens,
         }
-        if tools:
-            completion_kwargs['tools'] = [tool.model_dump() for tool in tools]
-            completion_kwargs['tool_choice'] = ToolChoice.auto
 
         async for output in self.llm_service.stream_messages(
             **completion_kwargs
         ):
+            if output.tool_calls:
+                raise LLMCompletionError(
+                    kind=LLMCompletionErrorKind.invalid_response,
+                    message='Streaming tool calls are not yet supported',
+                )
             yield output
 
     @staticmethod

--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -219,12 +219,15 @@ class LLMService:
                         backend_status_code=response.status_code,
                     )
 
+                saw_done_marker = False
+
                 async for line in response.aiter_lines():
                     if not line.startswith('data: '):
                         continue
 
                     data = line[6:].strip()
                     if data == '[DONE]':
+                        saw_done_marker = True
                         break
 
                     try:
@@ -239,6 +242,12 @@ class LLMService:
                             exc_info=exc,
                         )
                         continue
+
+                if not saw_done_marker:
+                    raise LLMCompletionError(
+                        kind=LLMCompletionErrorKind.invalid_response,
+                        message='LLM stream did not terminate with [DONE]',
+                    )
 
         except httpx.TimeoutException as exc:
             raise LLMCompletionError(

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -1,5 +1,6 @@
 """Tests for ConversationService."""
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 import json
 from unittest.mock import AsyncMock, Mock, patch
@@ -4173,9 +4174,11 @@ async def test_add_message_to_conversation_stream_persists_lifecycle_success(
         event for event in all_events if event.startswith('event: done')
     )
     done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['conversation_id'] == str(conversation.id)
     assert done_payload['content'] == 'Hello world'
     assert done_payload['model'] == 'test-model'
     assert done_payload['usage']['total_tokens'] == 6
+    assert done_payload['annotations']['thought'] == 'thinking...'
 
     result = await async_session.execute(
         select(Message)
@@ -4305,6 +4308,117 @@ async def test_add_message_to_conversation_stream_skips_assistant_persistence_wi
     assert persisted_messages[0].role == 'user'
 
 
+async def test_add_message_to_conversation_stream_errors_on_tool_calls(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Streaming path emits terminal error when model returns tool calls."""
+    conversation = Conversation(user_id=test_user_id, title='Streaming Tool')
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger tool call'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_1',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='{}'
+                    ),
+                )
+            ]
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Trigger tool call')
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert len(emitted_events) == 1
+    assert emitted_events[0].startswith('event: error')
+    error_payload = json.loads(emitted_events[0].split('data: ', 1)[1].strip())
+    assert 'not yet supported' in error_payload['detail'].lower()
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 1
+    assert persisted_messages[0].role == 'user'
+
+
+async def test_add_message_to_conversation_stream_persists_partial_on_cancellation(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Client cancellation persists assistant partial output in terminal error state."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Cancellation'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger cancellation'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='partial output')
+        raise asyncio.CancelledError()
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Trigger cancellation')
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in conversation_service.add_message_to_conversation_stream(
+            session=async_session,
+            user_id=test_user_id,
+            conversation_id=conversation.id,
+            payload=payload,
+        ):
+            pass
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'partial output'
+    assert 'interrupted' in (persisted_messages[1].error or '').lower()
+
+
 async def test_create_conversation_with_message_stream_persists_lifecycle_success(
     conversation_service,
     mock_llm_service,
@@ -4369,8 +4483,10 @@ async def test_create_conversation_with_message_stream_persists_lifecycle_succes
         event for event in all_events if event.startswith('event: done')
     )
     done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['conversation_id'] == str(conversations[0].id)
     assert done_payload['content'] == 'Hello world'
     assert done_payload['model'] == 'test-model'
+    assert done_payload['annotations']['thought'] == 'thinking...'
 
     result = await async_session.execute(
         select(Message)

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -1,6 +1,7 @@
 """Tests for ConversationService."""
 
 from datetime import datetime, timedelta, timezone
+import json
 from unittest.mock import AsyncMock, Mock, patch
 import uuid
 
@@ -25,9 +26,11 @@ from assistant.models.conversation_sql import Conversation, Message
 from assistant.models.llm import (
     ChatCompletionMessageToolCall,
     ChatCompletionMessageToolCallFunction,
+    CompletionUsage,
     LLMCompletionError,
     LLMCompletionErrorKind,
     LLMCompletionResult,
+    StreamParserOutput,
 )
 from assistant.models.tool import (
     ToolExecutionResult,
@@ -4099,3 +4102,393 @@ async def test_extract_and_save_background_indexing_failure_nonfatal():
     mock_memory_storage.upsert_conversation_summary.assert_called_once()
     # Verify enrichment still happened
     service._enrich_assistant_annotations_with_memory_saved.assert_called_once()
+
+
+async def test_add_message_to_conversation_stream_persists_lifecycle_success(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Streaming path persists user immediately and assistant on terminal completion."""
+    conversation = Conversation(user_id=test_user_id, title='Streaming Test')
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Hello stream'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(thought='thinking...')
+        yield StreamParserOutput(token='Hello')
+        yield StreamParserOutput(
+            token=' world',
+            finish_reason='stop',
+            usage=CompletionUsage(
+                prompt_tokens=4,
+                completion_tokens=2,
+                total_tokens=6,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Hello stream')
+
+    stream = conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    )
+
+    first_event = await anext(stream)
+
+    # User message should already be durable before stream completion.
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    in_flight_messages = list(result.scalars().all())
+    assert len(in_flight_messages) == 1
+    assert in_flight_messages[0].role == 'user'
+    assert in_flight_messages[0].content == 'Hello stream'
+
+    remaining_events = []
+    async for event in stream:
+        remaining_events.append(event)
+
+    all_events = [first_event] + remaining_events
+    assert any(event.startswith('event: thought') for event in all_events)
+    assert any(event.startswith('event: token') for event in all_events)
+    done_event = next(
+        event for event in all_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['content'] == 'Hello world'
+    assert done_payload['model'] == 'test-model'
+    assert done_payload['usage']['total_tokens'] == 6
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Hello world'
+    assert persisted_messages[1].error is None
+    assert persisted_messages[1].annotations['thought'] == 'thinking...'
+
+
+async def test_add_message_to_conversation_stream_persists_error_with_partial_assistant(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Interrupted streams persist partial assistant output in terminal error state."""
+    conversation = Conversation(user_id=test_user_id, title='Streaming Error')
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger stream error'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='partial output')
+        raise LLMCompletionError(
+            kind=LLMCompletionErrorKind.timeout,
+            message='LLM request timed out',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Trigger stream error')
+
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert any(event.startswith('event: token') for event in emitted_events)
+    error_event = next(
+        event for event in emitted_events if event.startswith('event: error')
+    )
+    error_payload = json.loads(error_event.split('data: ', 1)[1].strip())
+    assert 'timed out' in error_payload['detail'].lower()
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'partial output'
+    assert 'timed out' in (persisted_messages[1].error or '').lower()
+    assert persisted_messages[1].annotations['failure']['stage'] == 'llm'
+
+
+async def test_add_message_to_conversation_stream_skips_assistant_persistence_without_output(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """If stream fails before output starts, only the user message is persisted."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Early Failure'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Fail immediately'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        raise LLMCompletionError(
+            kind=LLMCompletionErrorKind.unreachable,
+            message='Failed to reach LLM backend',
+        )
+        yield  # pragma: no cover
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Fail immediately')
+
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert len(emitted_events) == 1
+    assert emitted_events[0].startswith('event: error')
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 1
+    assert persisted_messages[0].role == 'user'
+
+
+async def test_create_conversation_with_message_stream_persists_lifecycle_success(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """New conversation stream persists user immediately and assistant on completion."""
+    mock_context_assembly.assemble_context_new_conversation.return_value = (
+        ContextAssemblyResult(
+            messages=[{'role': 'user', 'content': 'Start stream'}],
+            used_summary=False,
+            summary_id=None,
+            fact_ids=[],
+        )
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(thought='thinking...')
+        yield StreamParserOutput(token='Hello')
+        yield StreamParserOutput(
+            token=' world',
+            finish_reason='stop',
+            usage=CompletionUsage(
+                prompt_tokens=4,
+                completion_tokens=2,
+                total_tokens=6,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateConversationWithMessageRequest(content='Start stream')
+    stream = conversation_service.create_conversation_with_message_stream(
+        session=async_session,
+        user_id=test_user_id,
+        payload=payload,
+    )
+    first_event = await anext(stream)
+
+    result = await async_session.execute(select(Conversation))
+    conversations = list(result.scalars().all())
+    assert len(conversations) == 1
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversations[0].id)
+        .order_by(Message.sequence_number.asc())
+    )
+    in_flight_messages = list(result.scalars().all())
+    assert len(in_flight_messages) == 1
+    assert in_flight_messages[0].role == 'user'
+    assert in_flight_messages[0].content == 'Start stream'
+
+    remaining_events = []
+    async for event in stream:
+        remaining_events.append(event)
+
+    all_events = [first_event] + remaining_events
+    done_event = next(
+        event for event in all_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['content'] == 'Hello world'
+    assert done_payload['model'] == 'test-model'
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversations[0].id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Hello world'
+    assert persisted_messages[1].annotations['thought'] == 'thinking...'
+
+
+async def test_create_conversation_with_message_stream_persists_error_with_partial_assistant(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Interrupted new-conversation stream persists partial assistant in error state."""
+    mock_context_assembly.assemble_context_new_conversation.return_value = (
+        ContextAssemblyResult(
+            messages=[{'role': 'user', 'content': 'Start stream'}],
+            used_summary=False,
+            summary_id=None,
+            fact_ids=[],
+        )
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='partial output')
+        raise LLMCompletionError(
+            kind=LLMCompletionErrorKind.timeout,
+            message='LLM request timed out',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateConversationWithMessageRequest(content='Start stream')
+    emitted_events = []
+    async for (
+        event
+    ) in conversation_service.create_conversation_with_message_stream(
+        session=async_session,
+        user_id=test_user_id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert any(event.startswith('event: token') for event in emitted_events)
+    assert any(event.startswith('event: error') for event in emitted_events)
+
+    result = await async_session.execute(select(Conversation))
+    conversations = list(result.scalars().all())
+    assert len(conversations) == 1
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversations[0].id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'partial output'
+    assert persisted_messages[1].annotations['failure']['stage'] == 'llm'
+
+
+async def test_create_conversation_with_message_stream_skips_assistant_persistence_without_output(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """If new-conversation stream fails before output, only user message is persisted."""
+    mock_context_assembly.assemble_context_new_conversation.return_value = (
+        ContextAssemblyResult(
+            messages=[{'role': 'user', 'content': 'Start stream'}],
+            used_summary=False,
+            summary_id=None,
+            fact_ids=[],
+        )
+    )
+
+    async def stream_outputs():
+        raise LLMCompletionError(
+            kind=LLMCompletionErrorKind.unreachable,
+            message='Failed to reach LLM backend',
+        )
+        yield  # pragma: no cover
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateConversationWithMessageRequest(content='Start stream')
+    emitted_events = []
+    async for (
+        event
+    ) in conversation_service.create_conversation_with_message_stream(
+        session=async_session,
+        user_id=test_user_id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert len(emitted_events) == 1
+    assert emitted_events[0].startswith('event: error')
+
+    result = await async_session.execute(select(Conversation))
+    conversations = list(result.scalars().all())
+    assert len(conversations) == 1
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversations[0].id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 1
+    assert persisted_messages[0].role == 'user'

--- a/apps/assistant-backend/tests/services/test_llm_service.py
+++ b/apps/assistant-backend/tests/services/test_llm_service.py
@@ -509,3 +509,51 @@ async def test_stream_messages_backend_error():
         assert exc_info.value.backend_status_code == 500
     finally:
         await service.aclose()
+
+
+async def test_stream_messages_raises_on_missing_done_marker():
+    """It raises invalid_response when stream ends without [DONE]."""
+    messages = [{'role': 'user', 'content': 'Hello'}]
+
+    chunks = [
+        {
+            'id': '1',
+            'object': 'chat.completion.chunk',
+            'created': 1,
+            'model': 'test',
+            'choices': [
+                {'index': 0, 'delta': {'content': 'Hi'}, 'finish_reason': None}
+            ],
+        }
+    ]
+    sse_content = ''.join([f'data: {json.dumps(c)}\n\n' for c in chunks])
+    # Intentionally no "data: [DONE]"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=sse_content.encode('utf-8'),
+            headers={'content-type': 'text/event-stream'},
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url='http://test')
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
+
+    try:
+        with pytest.raises(LLMCompletionError) as exc_info:
+            async for _ in service.stream_messages(
+                messages=messages,
+                model='test-model',
+                temperature=0.7,
+                max_tokens=128,
+            ):
+                pass
+
+        assert exc_info.value.kind == LLMCompletionErrorKind.invalid_response
+        assert 'did not terminate' in exc_info.value.message.lower()
+    finally:
+        await service.aclose()


### PR DESCRIPTION
## Summary
- implement streaming lifecycle methods in ConversationService for both new and existing conversations
- persist user messages immediately and persist assistant messages only on terminal states
- enforce explicit `[DONE]` stream termination in LLMService to prevent silent truncated-success persistence
- add full backend regression coverage for success, interrupted stream with partial assistant persistence, and fail-before-output paths

## Validation
- uv run ruff format src/ tests/
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pyrefly check src/
- uv run pytest -v

## Notes
- this closes the previously identified review concerns around truncated stream handling and missing create-conversation streaming lifecycle parity tests.
