### PR TITLE
Fix streaming transcript reconciliation and remove settings delta

### DIFF
--- a/apps/assistant-backend/src/assistant/models/conversation.py
+++ b/apps/assistant-backend/src/assistant/models/conversation.py
@@ -28,12 +28,14 @@ class CreateConversationWithMessageRequest(BaseModel):
     content: str
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
     max_tokens: int | None = Field(default=512, ge=1, le=4096)
+    stream: bool = False
 
 
 class CreateMessageRequest(BaseModel):
     content: str
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
     max_tokens: int | None = Field(default=512, ge=1, le=4096)
+    stream: bool = False
 
 
 class ConversationWithMessagesResponse(BaseModel):

--- a/apps/assistant-backend/src/assistant/routers/conversations.py
+++ b/apps/assistant-backend/src/assistant/routers/conversations.py
@@ -1,8 +1,10 @@
 """REST API handler for user conversations."""
 
+import logging
 import uuid
 
 from fastapi import APIRouter, BackgroundTasks, Request, status
+from fastapi.responses import StreamingResponse
 
 from assistant.models.conversation import (
     ConversationWithMessagesResponse,
@@ -16,6 +18,7 @@ from assistant.services import get_conversation_service
 from assistant.utils.database import DBSession
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get(
@@ -67,9 +70,32 @@ async def create_conversation_with_message(
     user: CurrentUser,
     session: DBSession,
     background_tasks: BackgroundTasks,
-) -> ConversationWithMessagesResponse:
+) -> ConversationWithMessagesResponse | StreamingResponse:
     """Create a new conversation with an initial user message."""
     conversation_service = get_conversation_service()
+    logger.debug(
+        'create_conversation_with_message called: stream=%s content_len=%s',
+        payload.stream,
+        len(payload.content or ''),
+    )
+    if payload.stream:
+        logger.debug('Dispatching create_conversation_with_message_stream')
+        return StreamingResponse(
+            conversation_service.create_conversation_with_message_stream(
+                session=session,
+                user_id=user.userid,
+                payload=payload,
+                background_tasks=background_tasks,
+            ),
+            status_code=status.HTTP_201_CREATED,
+            media_type='text/event-stream',
+            headers={
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+                'X-Accel-Buffering': 'no',
+            },
+        )
+
     return await conversation_service.create_conversation_with_message(
         session=session,
         user_id=user.userid,
@@ -90,8 +116,36 @@ async def add_message_to_conversation(
     user: CurrentUser,
     session: DBSession,
     background_tasks: BackgroundTasks,
-) -> ConversationWithMessagesResponse:
+) -> ConversationWithMessagesResponse | StreamingResponse:
     conversation_service = get_conversation_service()
+    logger.debug(
+        'add_message_to_conversation called: conversation_id=%s stream=%s content_len=%s',
+        conversation_id,
+        payload.stream,
+        len(payload.content or ''),
+    )
+    if payload.stream:
+        logger.debug(
+            'Dispatching add_message_to_conversation_stream for conversation_id=%s',
+            conversation_id,
+        )
+        return StreamingResponse(
+            conversation_service.add_message_to_conversation_stream(
+                session=session,
+                user_id=user.userid,
+                conversation_id=conversation_id,
+                payload=payload,
+                background_tasks=background_tasks,
+            ),
+            status_code=status.HTTP_201_CREATED,
+            media_type='text/event-stream',
+            headers={
+                'Cache-Control': 'no-cache',
+                'Connection': 'keep-alive',
+                'X-Accel-Buffering': 'no',
+            },
+        )
+
     return await conversation_service.add_message_to_conversation(
         session=session,
         user_id=user.userid,

--- a/apps/assistant-backend/src/assistant/routers/conversations.py
+++ b/apps/assistant-backend/src/assistant/routers/conversations.py
@@ -20,6 +20,21 @@ from assistant.utils.database import DBSession
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+STREAMING_RESPONSE_SCHEMA = {
+    'description': 'JSON response or SSE stream when `stream=true`.',
+    'content': {
+        'application/json': {
+            'schema': ConversationWithMessagesResponse.model_json_schema()
+        },
+        'text/event-stream': {
+            'schema': {
+                'type': 'string',
+                'example': 'event: token\ndata: "Hello"\n\n',
+            }
+        },
+    },
+}
+
 
 @router.get(
     '',
@@ -61,7 +76,8 @@ async def get_conversation_messages(
     '/with-message',
     response_description='Return HTTP Status Code 201 (OK)',
     status_code=status.HTTP_201_CREATED,
-    response_model=ConversationWithMessagesResponse,
+    response_model=None,
+    responses={status.HTTP_201_CREATED: STREAMING_RESPONSE_SCHEMA},
     include_in_schema=True,
 )
 async def create_conversation_with_message(
@@ -96,18 +112,21 @@ async def create_conversation_with_message(
             },
         )
 
-    return await conversation_service.create_conversation_with_message(
-        session=session,
-        user_id=user.userid,
-        payload=payload,
-        background_tasks=background_tasks,
+    return ConversationWithMessagesResponse.model_validate(
+        await conversation_service.create_conversation_with_message(
+            session=session,
+            user_id=user.userid,
+            payload=payload,
+            background_tasks=background_tasks,
+        )
     )
 
 
 @router.post(
     '/{conversation_id}/messages',
     status_code=status.HTTP_201_CREATED,
-    response_model=ConversationWithMessagesResponse,
+    response_model=None,
+    responses={status.HTTP_201_CREATED: STREAMING_RESPONSE_SCHEMA},
 )
 async def add_message_to_conversation(
     request: Request,
@@ -146,10 +165,12 @@ async def add_message_to_conversation(
             },
         )
 
-    return await conversation_service.add_message_to_conversation(
-        session=session,
-        user_id=user.userid,
-        conversation_id=conversation_id,
-        payload=payload,
-        background_tasks=background_tasks,
+    return ConversationWithMessagesResponse.model_validate(
+        await conversation_service.add_message_to_conversation(
+            session=session,
+            user_id=user.userid,
+            conversation_id=conversation_id,
+            payload=payload,
+            background_tasks=background_tasks,
+        )
     )

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -540,20 +540,6 @@ class ConversationService:
                     emitted_tokens += 1
                     yield SSEEncoder.encode('token', output.token)
 
-                if output.tool_calls:
-                    stream_started = True
-                    for tool_call in output.tool_calls:
-                        emitted_tool_calls += 1
-                        logger.debug(
-                            'stream tool_call event: conversation_id=%s tool_name=%s tool_call_id=%s (event only; execution currently handled in non-stream tool loop)',
-                            conversation.id,
-                            tool_call.function.name,
-                            tool_call.id,
-                        )
-                        yield SSEEncoder.encode(
-                            'tool_call', tool_call.model_dump()
-                        )
-
                 if output.model:
                     model_name = output.model
                 if output.usage:

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,6 +1,5 @@
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime, timezone
 import json
 import logging
 from typing import AsyncGenerator, cast
@@ -284,6 +283,7 @@ class ConversationService:
             sequence_number=next_seq,
         )
         session.add(user_message)
+        conversation_id = conversation.id
         await session.commit()
         await session.refresh(user_message)
 
@@ -403,6 +403,7 @@ class ConversationService:
             sequence_number=1,
         )
         session.add(user_message)
+        conversation_id = conversation.id
         await session.commit()
         await session.refresh(user_message)
 
@@ -417,7 +418,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation=conversation,
+            conversation_id=conversation_id,
             user_message_id=user_message.id,
             assistant_sequence_number=2,
             context_messages=context_result.messages,
@@ -481,7 +482,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation=conversation,
+            conversation_id=conversation_id,
             user_message_id=user_message.id,
             assistant_sequence_number=next_seq + 1,
             context_messages=context_result.messages,
@@ -497,7 +498,7 @@ class ConversationService:
         *,
         session: AsyncSession,
         user_id: str,
-        conversation: Conversation,
+        conversation_id: uuid.UUID,
         user_message_id: uuid.UUID,
         assistant_sequence_number: int,
         context_messages: list[dict],
@@ -507,11 +508,20 @@ class ConversationService:
         background_tasks: BackgroundTasks | None = None,
     ) -> AsyncGenerator[str, None]:
         """Run streaming loop and persist assistant row only at terminal states."""
+        logger.debug(
+            'stream lifecycle start: conversation_id=%s user_message_id=%s seq=%s',
+            conversation_id,
+            user_message_id,
+            assistant_sequence_number,
+        )
         content_parts: list[str] = []
         thought_parts: list[str] = []
         model_name: str | None = None
         usage_payload: dict | None = None
         stream_started = False
+        emitted_tokens = 0
+        emitted_thoughts = 0
+        emitted_tool_calls = 0
 
         try:
             async for output in self._call_llm_chat_completion_stream(
@@ -522,16 +532,25 @@ class ConversationService:
                 if output.thought:
                     thought_parts.append(output.thought)
                     stream_started = True
+                    emitted_thoughts += 1
                     yield SSEEncoder.encode('thought', output.thought)
 
                 if output.token:
                     content_parts.append(output.token)
                     stream_started = True
+                    emitted_tokens += 1
                     yield SSEEncoder.encode('token', output.token)
 
                 if output.tool_calls:
                     stream_started = True
                     for tool_call in output.tool_calls:
+                        emitted_tool_calls += 1
+                        logger.debug(
+                            'stream tool_call event: conversation_id=%s tool_name=%s tool_call_id=%s (event only; execution currently handled in non-stream tool loop)',
+                            conversation_id,
+                            tool_call.function.name,
+                            tool_call.id,
+                        )
                         yield SSEEncoder.encode(
                             'tool_call', tool_call.model_dump()
                         )
@@ -542,10 +561,20 @@ class ConversationService:
                     usage_payload = output.usage.model_dump()
 
         except LLMCompletionError as error:
+            logger.debug(
+                'stream lifecycle llm error: conversation_id=%s stream_started=%s token_events=%s thought_events=%s tool_call_events=%s kind=%s detail=%s',
+                conversation_id,
+                stream_started,
+                emitted_tokens,
+                emitted_thoughts,
+                emitted_tool_calls,
+                error.kind.value,
+                error.message,
+            )
             if stream_started:
                 await self._persist_streaming_assistant_message(
                     session=session,
-                    conversation=conversation,
+                    conversation_id=conversation_id,
                     sequence_number=assistant_sequence_number,
                     content=''.join(content_parts)
                     or 'Unable to generate a response. Please try again.',
@@ -566,6 +595,14 @@ class ConversationService:
             return
 
         except asyncio.CancelledError:
+            logger.debug(
+                'stream lifecycle cancelled: conversation_id=%s stream_started=%s token_events=%s thought_events=%s tool_call_events=%s',
+                conversation_id,
+                stream_started,
+                emitted_tokens,
+                emitted_thoughts,
+                emitted_tool_calls,
+            )
             if stream_started:
                 cancellation_error = LLMCompletionError(
                     kind=LLMCompletionErrorKind.backend_error,
@@ -573,7 +610,7 @@ class ConversationService:
                 )
                 await self._persist_streaming_assistant_message(
                     session=session,
-                    conversation=conversation,
+                    conversation_id=conversation_id,
                     sequence_number=assistant_sequence_number,
                     content=''.join(content_parts)
                     or 'Unable to generate a response. Please try again.',
@@ -585,7 +622,7 @@ class ConversationService:
 
         assistant_message = await self._persist_streaming_assistant_message(
             session=session,
-            conversation=conversation,
+            conversation_id=conversation_id,
             sequence_number=assistant_sequence_number,
             content=''.join(content_parts)
             or 'Unable to generate a response. Please try again.',
@@ -593,18 +630,27 @@ class ConversationService:
             fact_ids=fact_ids,
             error=None,
         )
+        logger.debug(
+            'stream lifecycle done: conversation_id=%s assistant_message_id=%s token_events=%s thought_events=%s tool_call_events=%s content_len=%s',
+            conversation_id,
+            assistant_message.id,
+            emitted_tokens,
+            emitted_thoughts,
+            emitted_tool_calls,
+            len(assistant_message.content or ''),
+        )
 
         if background_tasks and self.memory_storage:
             background_tasks.add_task(
                 self.extract_and_save_background,
                 user_id=user_id,
-                conversation_id=conversation.id,
+                conversation_id=conversation_id,
                 assistant_message_id=assistant_message.id,
                 latest_user_message_id=user_message_id,
             )
 
         done_payload: dict[str, object] = {
-            'conversation_id': str(conversation.id),
+            'conversation_id': str(conversation_id),
             'message_id': str(assistant_message.id),
             'content': assistant_message.content,
             'annotations': assistant_message.annotations,
@@ -620,7 +666,7 @@ class ConversationService:
         self,
         *,
         session: AsyncSession,
-        conversation: Conversation,
+        conversation_id: uuid.UUID,
         sequence_number: int,
         content: str,
         thought: str | None,
@@ -646,7 +692,7 @@ class ConversationService:
             annotations_obj.thought = thought
 
         assistant_message = Message(
-            conversation_id=conversation.id,
+            conversation_id=conversation_id,
             role='assistant',
             content=content,
             sequence_number=sequence_number,
@@ -654,7 +700,12 @@ class ConversationService:
             annotations=annotations_obj.model_dump(),
         )
         session.add(assistant_message)
-        conversation.updated_at = datetime.now(timezone.utc)
+        await session.execute(
+            update(Conversation)
+            # pyrefly: ignore [bad-argument-type]
+            .where(Conversation.id == conversation_id)
+            .values(updated_at=func.now())
+        )
         await session.commit()
         await session.refresh(assistant_message)
         return assistant_message
@@ -737,6 +788,20 @@ class ConversationService:
                 result = await self.llm_service.complete_messages(
                     **completion_kwargs
                 )
+                logger.debug(
+                    'conversation llm turn complete: finish_reason=%s usage(prompt=%s completion=%s total=%s) tool_calls=%s',
+                    result.finish_reason,
+                    result.prompt_tokens,
+                    result.completion_tokens,
+                    result.total_tokens,
+                    len(result.tool_calls or []),
+                )
+                if result.finish_reason == 'length':
+                    logger.debug(
+                        'conversation llm turn likely truncated: max_tokens=%s total_tokens=%s',
+                        max_tokens,
+                        result.total_tokens,
+                    )
 
                 # No tool calls - return final response
                 if not result.tool_calls:
@@ -756,6 +821,11 @@ class ConversationService:
                 )
 
                 for tool_call in result.tool_calls:
+                    logger.debug(
+                        'llm requested tool execution: name=%s tool_call_id=%s',
+                        tool_call.function.name,
+                        tool_call.id,
+                    )
                     # Parse and validate tool arguments safely
                     try:
                         parsed_arguments = json.loads(
@@ -860,6 +930,17 @@ class ConversationService:
         async for output in self.llm_service.stream_messages(
             **completion_kwargs
         ):
+            if output.finish_reason is not None:
+                logger.debug(
+                    'conversation streaming turn complete: finish_reason=%s usage=%s',
+                    output.finish_reason,
+                    output.usage.model_dump() if output.usage else None,
+                )
+                if output.finish_reason == 'length':
+                    logger.debug(
+                        'conversation streaming turn likely truncated: max_tokens=%s',
+                        max_tokens,
+                    )
             if output.tool_calls:
                 raise LLMCompletionError(
                     kind=LLMCompletionErrorKind.invalid_response,

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import json
 import logging
 from typing import AsyncGenerator, cast
@@ -698,7 +699,7 @@ class ConversationService:
             annotations=annotations_obj.model_dump(),
         )
         session.add(assistant_message)
-        conversation.updated_at = func.now()
+        conversation.updated_at = datetime.now(timezone.utc)
         await session.commit()
         await session.refresh(assistant_message)
         return assistant_message

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -283,7 +283,6 @@ class ConversationService:
             sequence_number=next_seq,
         )
         session.add(user_message)
-        conversation_id = conversation.id
         await session.commit()
         await session.refresh(user_message)
 
@@ -446,7 +445,7 @@ class ConversationService:
                 detail='Message content cannot be empty',
             )
 
-        conversation = await self._get_conversation_for_user(
+        await self._get_conversation_for_user(
             session,
             user_id=user_id,
             conversation_id=conversation_id,

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -402,7 +402,6 @@ class ConversationService:
             sequence_number=1,
         )
         session.add(user_message)
-        conversation_id = conversation.id
         await session.commit()
         await session.refresh(user_message)
 
@@ -417,7 +416,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation_id=conversation_id,
+            conversation=conversation,
             user_message_id=user_message.id,
             assistant_sequence_number=2,
             context_messages=context_result.messages,
@@ -445,7 +444,7 @@ class ConversationService:
                 detail='Message content cannot be empty',
             )
 
-        await self._get_conversation_for_user(
+        conversation = await self._get_conversation_for_user(
             session,
             user_id=user_id,
             conversation_id=conversation_id,
@@ -481,7 +480,7 @@ class ConversationService:
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
-            conversation_id=conversation_id,
+            conversation=conversation,
             user_message_id=user_message.id,
             assistant_sequence_number=next_seq + 1,
             context_messages=context_result.messages,
@@ -497,7 +496,7 @@ class ConversationService:
         *,
         session: AsyncSession,
         user_id: str,
-        conversation_id: uuid.UUID,
+        conversation: Conversation,
         user_message_id: uuid.UUID,
         assistant_sequence_number: int,
         context_messages: list[dict],
@@ -509,7 +508,7 @@ class ConversationService:
         """Run streaming loop and persist assistant row only at terminal states."""
         logger.debug(
             'stream lifecycle start: conversation_id=%s user_message_id=%s seq=%s',
-            conversation_id,
+            conversation.id,
             user_message_id,
             assistant_sequence_number,
         )
@@ -546,7 +545,7 @@ class ConversationService:
                         emitted_tool_calls += 1
                         logger.debug(
                             'stream tool_call event: conversation_id=%s tool_name=%s tool_call_id=%s (event only; execution currently handled in non-stream tool loop)',
-                            conversation_id,
+                            conversation.id,
                             tool_call.function.name,
                             tool_call.id,
                         )
@@ -562,7 +561,7 @@ class ConversationService:
         except LLMCompletionError as error:
             logger.debug(
                 'stream lifecycle llm error: conversation_id=%s stream_started=%s token_events=%s thought_events=%s tool_call_events=%s kind=%s detail=%s',
-                conversation_id,
+                conversation.id,
                 stream_started,
                 emitted_tokens,
                 emitted_thoughts,
@@ -573,7 +572,7 @@ class ConversationService:
             if stream_started:
                 await self._persist_streaming_assistant_message(
                     session=session,
-                    conversation_id=conversation_id,
+                    conversation=conversation,
                     sequence_number=assistant_sequence_number,
                     content=''.join(content_parts)
                     or 'Unable to generate a response. Please try again.',
@@ -596,7 +595,7 @@ class ConversationService:
         except asyncio.CancelledError:
             logger.debug(
                 'stream lifecycle cancelled: conversation_id=%s stream_started=%s token_events=%s thought_events=%s tool_call_events=%s',
-                conversation_id,
+                conversation.id,
                 stream_started,
                 emitted_tokens,
                 emitted_thoughts,
@@ -609,7 +608,7 @@ class ConversationService:
                 )
                 await self._persist_streaming_assistant_message(
                     session=session,
-                    conversation_id=conversation_id,
+                    conversation=conversation,
                     sequence_number=assistant_sequence_number,
                     content=''.join(content_parts)
                     or 'Unable to generate a response. Please try again.',
@@ -621,7 +620,7 @@ class ConversationService:
 
         assistant_message = await self._persist_streaming_assistant_message(
             session=session,
-            conversation_id=conversation_id,
+            conversation=conversation,
             sequence_number=assistant_sequence_number,
             content=''.join(content_parts)
             or 'Unable to generate a response. Please try again.',
@@ -631,7 +630,7 @@ class ConversationService:
         )
         logger.debug(
             'stream lifecycle done: conversation_id=%s assistant_message_id=%s token_events=%s thought_events=%s tool_call_events=%s content_len=%s',
-            conversation_id,
+            conversation.id,
             assistant_message.id,
             emitted_tokens,
             emitted_thoughts,
@@ -643,13 +642,13 @@ class ConversationService:
             background_tasks.add_task(
                 self.extract_and_save_background,
                 user_id=user_id,
-                conversation_id=conversation_id,
+                conversation_id=conversation.id,
                 assistant_message_id=assistant_message.id,
                 latest_user_message_id=user_message_id,
             )
 
         done_payload: dict[str, object] = {
-            'conversation_id': str(conversation_id),
+            'conversation_id': str(conversation.id),
             'message_id': str(assistant_message.id),
             'content': assistant_message.content,
             'annotations': assistant_message.annotations,
@@ -665,7 +664,7 @@ class ConversationService:
         self,
         *,
         session: AsyncSession,
-        conversation_id: uuid.UUID,
+        conversation: Conversation,
         sequence_number: int,
         content: str,
         thought: str | None,
@@ -691,7 +690,7 @@ class ConversationService:
             annotations_obj.thought = thought
 
         assistant_message = Message(
-            conversation_id=conversation_id,
+            conversation_id=conversation.id,
             role='assistant',
             content=content,
             sequence_number=sequence_number,
@@ -699,12 +698,7 @@ class ConversationService:
             annotations=annotations_obj.model_dump(),
         )
         session.add(assistant_message)
-        await session.execute(
-            update(Conversation)
-            # pyrefly: ignore [bad-argument-type]
-            .where(Conversation.id == conversation_id)
-            .values(updated_at=func.now())
-        )
+        conversation.updated_at = func.now()
         await session.commit()
         await session.refresh(assistant_message)
         return assistant_message

--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -119,6 +119,23 @@ class LLMService:
                 message='Failed to reach LLM backend',
             ) from exc
         except httpx.HTTPStatusError as exc:
+            error_body = exc.response.text[:1000] if exc.response else None
+            logger.error(
+                'LLM backend HTTP error: status=%s body=%s',
+                exc.response.status_code if exc.response else None,
+                error_body,
+            )
+            if error_body:
+                lowered = error_body.lower()
+                if (
+                    'context length' in lowered
+                    or 'maximum context length' in lowered
+                    or 'prompt is too long' in lowered
+                    or 'too many tokens' in lowered
+                ):
+                    logger.debug(
+                        'LLM likely hit context/token limits in non-stream request'
+                    )
             raise LLMCompletionError(
                 kind=LLMCompletionErrorKind.backend_error,
                 message='LLM backend returned an error',
@@ -153,6 +170,21 @@ class LLMService:
             )
 
         choice = response_obj.choices[0]
+        logger.debug(
+            'LLM completion finished: model=%s finish_reason=%s usage(prompt=%s completion=%s total=%s)',
+            response_obj.model,
+            choice.finish_reason,
+            response_obj.usage.prompt_tokens,
+            response_obj.usage.completion_tokens,
+            response_obj.usage.total_tokens,
+        )
+        if choice.finish_reason == 'length':
+            logger.debug(
+                'LLM completion truncated by token limit: model=%s max_tokens=%s usage_total=%s',
+                response_obj.model,
+                max_tokens,
+                response_obj.usage.total_tokens,
+            )
         return LLMCompletionResult(
             content=choice.message.content or '',
             model=response_obj.model,
@@ -212,7 +244,23 @@ class LLMService:
             ) as response:
                 if response.status_code != 200:
                     # Drain response to get error message if possible
-                    await response.aread()
+                    raw_body = await response.aread()
+                    body_text = raw_body.decode(errors='replace')[:1000]
+                    logger.error(
+                        'LLM streaming backend error: status=%s body=%s',
+                        response.status_code,
+                        body_text,
+                    )
+                    lowered = body_text.lower()
+                    if (
+                        'context length' in lowered
+                        or 'maximum context length' in lowered
+                        or 'prompt is too long' in lowered
+                        or 'too many tokens' in lowered
+                    ):
+                        logger.debug(
+                            'LLM likely hit context/token limits in stream request'
+                        )
                     raise LLMCompletionError(
                         kind=LLMCompletionErrorKind.backend_error,
                         message='LLM backend returned an error',
@@ -233,6 +281,21 @@ class LLMService:
                     try:
                         chunk_dict = json.loads(data)
                         output = parser.parse_chunk(chunk_dict)
+                        if output.finish_reason is not None:
+                            logger.debug(
+                                'LLM stream finished: model=%s finish_reason=%s usage=%s',
+                                output.model,
+                                output.finish_reason,
+                                output.usage.model_dump()
+                                if output.usage
+                                else None,
+                            )
+                            if output.finish_reason == 'length':
+                                logger.debug(
+                                    'LLM stream truncated by token limit: model=%s max_tokens=%s',
+                                    output.model,
+                                    max_tokens,
+                                )
                         yield output
                     except Exception as exc:
                         # Skip malformed chunks in the stream

--- a/apps/assistant-backend/src/assistant/services/llm_service.py
+++ b/apps/assistant-backend/src/assistant/services/llm_service.py
@@ -18,6 +18,38 @@ from assistant.services.stream_parser import StreamParser
 logger = logging.getLogger(__name__)
 
 
+def _extract_error_metadata(
+    body_text: str | None,
+) -> tuple[str | None, str | None]:
+    """Extract non-sensitive provider error metadata for logs."""
+    if not body_text:
+        return None, None
+
+    try:
+        payload = json.loads(body_text)
+    except json.JSONDecodeError:
+        return None, None
+
+    if not isinstance(payload, dict):
+        return None, None
+
+    error_obj = payload.get('error')
+    if isinstance(error_obj, dict):
+        code = error_obj.get('code')
+        error_type = error_obj.get('type')
+        return (
+            str(code) if code is not None else None,
+            str(error_type) if error_type is not None else None,
+        )
+
+    code = payload.get('code')
+    error_type = payload.get('type')
+    return (
+        str(code) if code is not None else None,
+        str(error_type) if error_type is not None else None,
+    )
+
+
 class LLMService:
     """Service for interacting with the LLM backend."""
 
@@ -120,11 +152,15 @@ class LLMService:
             ) from exc
         except httpx.HTTPStatusError as exc:
             error_body = exc.response.text[:1000] if exc.response else None
+            error_code, error_type = _extract_error_metadata(error_body)
             logger.error(
-                'LLM backend HTTP error: status=%s body=%s',
+                'LLM backend HTTP error: status=%s provider_error_code=%s provider_error_type=%s',
                 exc.response.status_code if exc.response else None,
-                error_body,
+                error_code,
+                error_type,
             )
+            if error_body:
+                logger.debug('LLM backend HTTP error body: %s', error_body)
             if error_body:
                 lowered = error_body.lower()
                 if (
@@ -246,11 +282,18 @@ class LLMService:
                     # Drain response to get error message if possible
                     raw_body = await response.aread()
                     body_text = raw_body.decode(errors='replace')[:1000]
+                    error_code, error_type = _extract_error_metadata(body_text)
                     logger.error(
-                        'LLM streaming backend error: status=%s body=%s',
+                        'LLM streaming backend error: status=%s provider_error_code=%s provider_error_type=%s',
                         response.status_code,
-                        body_text,
+                        error_code,
+                        error_type,
                     )
+                    if body_text:
+                        logger.debug(
+                            'LLM streaming backend error body: %s',
+                            body_text,
+                        )
                     lowered = body_text.lower()
                     if (
                         'context length' in lowered

--- a/apps/assistant-backend/src/assistant/services/tool_service.py
+++ b/apps/assistant-backend/src/assistant/services/tool_service.py
@@ -1,8 +1,13 @@
 """Service layer for exposing and executing allowed tools."""
 
+import logging
+import time
+
 from assistant.models.llm import ChatCompletionTool
 from assistant.models.tool import ToolExecutionResult
 from assistant.services.tools.factory import ToolFactory
+
+logger = logging.getLogger(__name__)
 
 
 class ToolService:
@@ -20,6 +25,27 @@ class ToolService:
         self, *, name: str, arguments: dict
     ) -> ToolExecutionResult:
         """Execute one named tool with already-parsed arguments."""
-
+        started = time.perf_counter()
+        logger.debug(
+            'tool execute requested: name=%s arg_keys=%s',
+            name,
+            sorted(arguments.keys()),
+        )
         tool = self.factory.get(name)
-        return await tool.execute(arguments)
+        try:
+            result = await tool.execute(arguments)
+            logger.debug(
+                'tool execute succeeded: name=%s status=%s duration_ms=%s',
+                name,
+                result.status.value,
+                int((time.perf_counter() - started) * 1000),
+            )
+            return result
+        except Exception:
+            logger.debug(
+                'tool execute failed: name=%s duration_ms=%s',
+                name,
+                int((time.perf_counter() - started) * 1000),
+                exc_info=True,
+            )
+            raise

--- a/apps/assistant-backend/src/assistant/services/tools/web_fetch.py
+++ b/apps/assistant-backend/src/assistant/services/tools/web_fetch.py
@@ -83,7 +83,7 @@ class WebFetchTool(BaseTool):
 
         url = arguments['url']
 
-        logger.debug('Starting web fetch for url: %s', url)
+        logger.debug('web_fetch start: url=%s', url)
 
         result = await self._perform_fetch(url)
 
@@ -98,8 +98,7 @@ class WebFetchTool(BaseTool):
         finished_at = datetime.now(UTC)
 
         logger.debug(
-            'Web fetch completed for url=%s title=%r content_length=%d '
-            'excerpt_length=%d',
+            'web_fetch done: url=%s title=%r content_length=%d excerpt_length=%d',
             payload.url,
             payload.title,
             len(payload.content),

--- a/apps/assistant-backend/src/assistant/services/tools/web_search.py
+++ b/apps/assistant-backend/src/assistant/services/tools/web_search.py
@@ -62,7 +62,7 @@ class WebSearchTool(BaseTool):
         num_results = arguments.get('num_results', DEFAULT_NUMBER_OF_RESULTS)
 
         logger.debug(
-            'Starting web_search, query_length=%d, num_results=%s',
+            'web_search start: query_length=%d num_results=%s',
             len(query),
             num_results,
         )
@@ -79,7 +79,7 @@ class WebSearchTool(BaseTool):
         finished_at = datetime.now(UTC)
 
         logger.debug(
-            'web_search completed with %s results in %s ms',
+            'web_search done: results=%s duration_ms=%s',
             len(results),
             int((finished_at - started_at).total_seconds() * 1000),
         )

--- a/apps/assistant-backend/src/assistant/settings.py
+++ b/apps/assistant-backend/src/assistant/settings.py
@@ -4,34 +4,10 @@ It uses Pydantic's BaseSettings to load environment variables from a `.env`
 file.
 """
 
-import json
-import os
-from typing import Any
-
-from pydantic import Field, field_validator
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from assistant.enums import Environment
-
-
-def parse_list_env_var(value: str | list[str]) -> list[str]:
-    """Parse comma-separated string into list."""
-    if isinstance(value, list):
-        return value
-    if not value or not value.strip():
-        return []
-    return [item.strip() for item in value.split(',') if item.strip()]
-
-
-# Pre-process environment variables that should be lists
-if 'CLIENT_ORIGINS' in os.environ:
-    os.environ['CLIENT_ORIGINS'] = json.dumps(
-        parse_list_env_var(os.environ['CLIENT_ORIGINS'])
-    )
-if 'ALLOWED_HOSTED_DOMAINS' in os.environ:
-    os.environ['ALLOWED_HOSTED_DOMAINS'] = json.dumps(
-        parse_list_env_var(os.environ['ALLOWED_HOSTED_DOMAINS'])
-    )
 
 
 class Settings(BaseSettings):
@@ -46,8 +22,7 @@ class Settings(BaseSettings):
     # FastAPI’s CORS middleware does NOT support wildcard subdomains.
     # Ensure to include all specific subdomains for the web application.
     client_origins: list[str] = Field(
-        default=["http://localhost:3000","http://localhost:5173","https://gpt.langleyclan.com"],
-        alias='CLIENT_ORIGINS'
+        default_factory=list, alias='CLIENT_ORIGINS'
     )
 
     # For authentication
@@ -129,17 +104,6 @@ class Settings(BaseSettings):
         description='The Chroma collection name for storing assistant memory.',
         alias='CHROMA_COLLECTION_NAME',
     )
-
-    @field_validator('client_origins', 'allowed_hosted_domains', mode='before')
-    @classmethod
-    def parse_comma_separated_list(cls, v: Any) -> list[str] | Any:
-        """Parse comma-separated strings into lists."""
-        print(f"Parsing value for list field: {v} (type: {type(v)})")
-        if isinstance(v, str):
-            if not v.strip():
-                return []
-            return [item.strip() for item in v.split(',') if item.strip()]
-        return v
 
 
 settings = Settings()  # pyrefly: ignore[missing-argument]

--- a/apps/assistant-backend/src/assistant/settings.py
+++ b/apps/assistant-backend/src/assistant/settings.py
@@ -4,10 +4,34 @@ It uses Pydantic's BaseSettings to load environment variables from a `.env`
 file.
 """
 
-from pydantic import Field
+import json
+import os
+from typing import Any
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from assistant.enums import Environment
+
+
+def parse_list_env_var(value: str | list[str]) -> list[str]:
+    """Parse comma-separated string into list."""
+    if isinstance(value, list):
+        return value
+    if not value or not value.strip():
+        return []
+    return [item.strip() for item in value.split(',') if item.strip()]
+
+
+# Pre-process environment variables that should be lists
+if 'CLIENT_ORIGINS' in os.environ:
+    os.environ['CLIENT_ORIGINS'] = json.dumps(
+        parse_list_env_var(os.environ['CLIENT_ORIGINS'])
+    )
+if 'ALLOWED_HOSTED_DOMAINS' in os.environ:
+    os.environ['ALLOWED_HOSTED_DOMAINS'] = json.dumps(
+        parse_list_env_var(os.environ['ALLOWED_HOSTED_DOMAINS'])
+    )
 
 
 class Settings(BaseSettings):
@@ -22,7 +46,8 @@ class Settings(BaseSettings):
     # FastAPI’s CORS middleware does NOT support wildcard subdomains.
     # Ensure to include all specific subdomains for the web application.
     client_origins: list[str] = Field(
-        default_factory=list, alias='CLIENT_ORIGINS'
+        default=["http://localhost:3000","http://localhost:5173","https://gpt.langleyclan.com"],
+        alias='CLIENT_ORIGINS'
     )
 
     # For authentication
@@ -104,6 +129,17 @@ class Settings(BaseSettings):
         description='The Chroma collection name for storing assistant memory.',
         alias='CHROMA_COLLECTION_NAME',
     )
+
+    @field_validator('client_origins', 'allowed_hosted_domains', mode='before')
+    @classmethod
+    def parse_comma_separated_list(cls, v: Any) -> list[str] | Any:
+        """Parse comma-separated strings into lists."""
+        print(f"Parsing value for list field: {v} (type: {type(v)})")
+        if isinstance(v, str):
+            if not v.strip():
+                return []
+            return [item.strip() for item in v.split(',') if item.strip()]
+        return v
 
 
 settings = Settings()  # pyrefly: ignore[missing-argument]

--- a/apps/assistant-backend/tests/routers/test_conversations.py
+++ b/apps/assistant-backend/tests/routers/test_conversations.py
@@ -1,6 +1,6 @@
 """Tests for conversations router endpoints."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -275,6 +275,38 @@ async def test_create_conversation_with_message_success(
     ]
 
 
+async def test_create_conversation_with_message_stream_success(
+    authenticated_async_test_client,
+):
+    """Test streaming response for conversation creation when stream=true."""
+
+    async def fake_stream():
+        yield 'event: token\ndata: "Hello"\n\n'
+        yield 'event: done\ndata: {"message_id":"m1","content":"Hello"}\n\n'
+
+    mock_service = Mock()
+    mock_service.create_conversation_with_message_stream = Mock(
+        return_value=fake_stream()
+    )
+    mock_service.create_conversation_with_message = AsyncMock()
+
+    with patch(
+        'assistant.routers.conversations.get_conversation_service',
+        return_value=mock_service,
+    ):
+        response = await authenticated_async_test_client.post(
+            '/api/v1/conversations/with-message',
+            json={'content': 'Hello', 'stream': True},
+        )
+
+    assert response.status_code == 201
+    assert response.headers['content-type'].startswith('text/event-stream')
+    assert 'event: token' in response.text
+    assert 'event: done' in response.text
+    mock_service.create_conversation_with_message_stream.assert_called_once()
+    mock_service.create_conversation_with_message.assert_not_called()
+
+
 async def test_create_conversation_with_message_default_params(
     authenticated_async_test_client,
 ):
@@ -483,6 +515,41 @@ async def test_add_message_to_conversation_success(
         data['assistant_message']['annotations']['memory_hits'][0]['label']
         == 'Saved family detail'
     )
+
+
+async def test_add_message_to_conversation_stream_success(
+    authenticated_async_test_client,
+):
+    """Test streaming response for add-message when stream=true."""
+    conv_id = str(uuid4())
+
+    async def fake_stream():
+        yield 'event: token\ndata: "Follow-up"\n\n'
+        yield (
+            'event: done\ndata: {"message_id":"m2","content":"Follow-up"}\n\n'
+        )
+
+    mock_service = Mock()
+    mock_service.add_message_to_conversation_stream = Mock(
+        return_value=fake_stream()
+    )
+    mock_service.add_message_to_conversation = AsyncMock()
+
+    with patch(
+        'assistant.routers.conversations.get_conversation_service',
+        return_value=mock_service,
+    ):
+        response = await authenticated_async_test_client.post(
+            f'/api/v1/conversations/{conv_id}/messages',
+            json={'content': 'Follow-up', 'stream': True},
+        )
+
+    assert response.status_code == 201
+    assert response.headers['content-type'].startswith('text/event-stream')
+    assert 'event: token' in response.text
+    assert 'event: done' in response.text
+    mock_service.add_message_to_conversation_stream.assert_called_once()
+    mock_service.add_message_to_conversation.assert_not_called()
 
 
 async def test_add_message_to_conversation_default_params(

--- a/apps/assistant-backend/tests/routers/test_conversations.py
+++ b/apps/assistant-backend/tests/routers/test_conversations.py
@@ -307,6 +307,22 @@ async def test_create_conversation_with_message_stream_success(
     mock_service.create_conversation_with_message.assert_not_called()
 
 
+async def test_create_conversation_with_message_openapi_documents_sse(
+    async_test_client,
+):
+    """Test OpenAPI documents both JSON and SSE response content types."""
+    response = await async_test_client.get('/openapi.json')
+
+    assert response.status_code == 200
+    schema = response.json()
+    content = schema['paths']['/api/v1/conversations/with-message']['post'][
+        'responses'
+    ]['201']['content']
+
+    assert 'application/json' in content
+    assert 'text/event-stream' in content
+
+
 async def test_create_conversation_with_message_default_params(
     authenticated_async_test_client,
 ):
@@ -550,6 +566,22 @@ async def test_add_message_to_conversation_stream_success(
     assert 'event: done' in response.text
     mock_service.add_message_to_conversation_stream.assert_called_once()
     mock_service.add_message_to_conversation.assert_not_called()
+
+
+async def test_add_message_to_conversation_openapi_documents_sse(
+    async_test_client,
+):
+    """Test OpenAPI documents both JSON and SSE for add-message route."""
+    response = await async_test_client.get('/openapi.json')
+
+    assert response.status_code == 200
+    schema = response.json()
+    content = schema['paths'][
+        '/api/v1/conversations/{conversation_id}/messages'
+    ]['post']['responses']['201']['content']
+
+    assert 'application/json' in content
+    assert 'text/event-stream' in content
 
 
 async def test_add_message_to_conversation_default_params(

--- a/apps/assistant-backend/tests/services/test_llm_service.py
+++ b/apps/assistant-backend/tests/services/test_llm_service.py
@@ -1,6 +1,7 @@
 """Tests for LLMService."""
 
 import json
+import logging
 from unittest.mock import AsyncMock
 
 import httpx
@@ -228,6 +229,63 @@ async def test_complete_messages_backend_error():
         assert exc_info.value.backend_status_code == 500
     finally:
         await service.aclose()
+
+
+async def test_complete_messages_backend_error_logs_redacted_metadata(
+    caplog,
+):
+    """It logs only non-sensitive backend error metadata at error level."""
+    response = httpx.Response(
+        500,
+        json={
+            'error': {
+                'code': 'context_length_exceeded',
+                'type': 'invalid_request_error',
+                'message': 'user prompt: tell me a secret',
+            }
+        },
+        request=httpx.Request('POST', 'http://test'),
+    )
+    error = httpx.HTTPStatusError(
+        'LLM error',
+        request=response.request,
+        response=response,
+    )
+
+    client = httpx.AsyncClient(base_url='http://test')
+    client.post = AsyncMock(side_effect=error)
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
+
+    try:
+        with caplog.at_level(
+            logging.ERROR, logger='assistant.services.llm_service'
+        ):
+            with pytest.raises(LLMCompletionError):
+                await service.complete_messages(
+                    messages=[],
+                    model='test',
+                    temperature=0.7,
+                    max_tokens=100,
+                )
+    finally:
+        await service.aclose()
+
+    error_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    ]
+    assert any(
+        'provider_error_code=context_length_exceeded' in msg
+        for msg in error_messages
+    )
+    assert any(
+        'provider_error_type=invalid_request_error' in msg
+        for msg in error_messages
+    )
+    assert all('tell me a secret' not in msg for msg in error_messages)
 
 
 async def test_complete_messages_invalid_response_shape():
@@ -509,6 +567,58 @@ async def test_stream_messages_backend_error():
         assert exc_info.value.backend_status_code == 500
     finally:
         await service.aclose()
+
+
+async def test_stream_messages_backend_error_logs_redacted_metadata(caplog):
+    """It avoids logging raw streaming error bodies at error level."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                'error': {
+                    'code': 'model_not_found',
+                    'type': 'invalid_request_error',
+                    'message': 'tool output: private family context',
+                }
+            },
+            request=request,
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url='http://test')
+    service = LLMService(
+        base_url='http://test', timeout_seconds=5, client=client
+    )
+
+    try:
+        with caplog.at_level(
+            logging.ERROR, logger='assistant.services.llm_service'
+        ):
+            with pytest.raises(LLMCompletionError):
+                async for _ in service.stream_messages(
+                    messages=[],
+                    model='test',
+                    temperature=0.7,
+                    max_tokens=100,
+                ):
+                    pass
+    finally:
+        await service.aclose()
+
+    error_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.ERROR
+    ]
+    assert any(
+        'provider_error_code=model_not_found' in msg for msg in error_messages
+    )
+    assert any(
+        'provider_error_type=invalid_request_error' in msg
+        for msg in error_messages
+    )
+    assert all('private family context' not in msg for msg in error_messages)
 
 
 async def test_stream_messages_raises_on_missing_done_marker():

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../lib/api", () => ({
   getConversationMessages: vi.fn(),
   createConversationWithMessage: vi.fn(),
   addMessageToConversation: vi.fn(),
+  streamConversation: vi.fn(),
 }));
 
 const mockListConversations = vi.mocked(api.listConversations);
@@ -20,6 +21,7 @@ const mockCreateConversationWithMessage = vi.mocked(
   api.createConversationWithMessage,
 );
 const mockAddMessageToConversation = vi.mocked(api.addMessageToConversation);
+const mockStreamConversation = vi.mocked(api.streamConversation);
 
 // Helper to render component with auth context
 function renderWithAuth(
@@ -123,6 +125,65 @@ describe("ConversationsChat", () => {
   });
 
   describe("New chat flow", () => {
+    it("streams the first assistant response and renders thought traces", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValueOnce({ items: [] });
+
+      async function* streamEvents() {
+        yield { event: "thought" as const, data: "Gathering context..." };
+        yield { event: "token" as const, data: "Hello" };
+        yield {
+          event: "done" as const,
+          data: {
+            conversation_id: "new-conv",
+            message_id: "assistant-1",
+            content: "Hello there",
+            annotations: {
+              thought: "Gathering context...",
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+            },
+          },
+        };
+      }
+
+      mockStreamConversation.mockReturnValueOnce(streamEvents());
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      );
+      await user.type(input, "Hello");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(mockStreamConversation).toHaveBeenCalledWith(
+          null,
+          "Hello",
+          expect.objectContaining({
+            signal: expect.any(AbortSignal),
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Hello there")).toBeInTheDocument();
+        expect(screen.getByText("Gathering context...")).toBeInTheDocument();
+      });
+    });
+
     it("shows welcome message when no conversation is selected", async () => {
       mockListConversations.mockResolvedValueOnce({ items: [] });
 

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -320,6 +320,43 @@ describe("ConversationsChat", () => {
       });
     });
 
+    it("keeps input text when stream and fallback both fail", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValueOnce({ items: [] });
+      mockCreateConversationWithMessage.mockRejectedValueOnce(
+        new Error("Fallback failed"),
+      );
+
+      async function* brokenStream() {
+        yield* [];
+      }
+
+      mockStreamConversation.mockReturnValueOnce(brokenStream());
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      ) as HTMLInputElement;
+      await user.type(input, "Hello");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/error:.*fallback failed/i),
+        ).toBeInTheDocument();
+      });
+      expect(input.value).toBe("Hello");
+    });
+
     it("does not send empty messages", async () => {
       const user = userEvent.setup();
       mockListConversations.mockResolvedValueOnce({ items: [] });
@@ -527,6 +564,153 @@ describe("ConversationsChat", () => {
       expect(mockGetConversationMessages).toHaveBeenNthCalledWith(2, "conv-1");
       expect(screen.getByText("Streamed answer")).toBeInTheDocument();
       expect(screen.getByText("Follow-up question")).toBeInTheDocument();
+    });
+
+    it("preserves newer optimistic messages while reconciliation is pending", async () => {
+      const user = userEvent.setup({ delay: null });
+
+      const mockConversations = {
+        items: [
+          {
+            id: "conv-1",
+            title: "Existing Conversation",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const initialTranscript = {
+        conversation: mockConversations.items[0],
+        items: [
+          {
+            id: "msg-1",
+            role: "user" as const,
+            content: "Previous question",
+            sequence_number: 1,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Previous answer",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+        ],
+      };
+
+      let resolveReconciledTranscript:
+        | ((value: typeof initialTranscript) => void)
+        | undefined;
+      const delayedReconciledTranscript = new Promise<typeof initialTranscript>(
+        (resolve) => {
+          resolveReconciledTranscript = resolve;
+        },
+      );
+
+      const reconciledTranscript = {
+        conversation: mockConversations.items[0],
+        items: [
+          ...initialTranscript.items,
+          {
+            id: "persisted-user-3",
+            role: "user" as const,
+            content: "First streamed follow-up",
+            sequence_number: 3,
+            created_at: "2024-01-01T00:01:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "persisted-assistant-4",
+            role: "assistant" as const,
+            content: "Streamed answer",
+            sequence_number: 4,
+            created_at: "2024-01-01T00:01:02Z",
+            error: null,
+            annotations: null,
+          },
+        ],
+      };
+
+      async function* firstStream() {
+        yield { event: "token" as const, data: "Streamed answer" };
+        yield {
+          event: "done" as const,
+          data: {
+            conversation_id: "conv-1",
+            message_id: "persisted-assistant-4",
+            content: "Streamed answer",
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+            },
+          },
+        };
+      }
+
+      async function* brokenStream() {
+        yield* [];
+      }
+
+      mockListConversations.mockResolvedValue(mockConversations);
+      mockGetConversationMessages
+        .mockResolvedValueOnce(initialTranscript)
+        .mockReturnValueOnce(delayedReconciledTranscript);
+      mockStreamConversation
+        .mockReturnValueOnce(firstStream())
+        .mockReturnValueOnce(brokenStream());
+      mockAddMessageToConversation.mockRejectedValueOnce(
+        new Error("Fallback failed"),
+      );
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(screen.getByText("Existing Conversation")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Existing Conversation"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Previous question")).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type your message/i,
+      ) as HTMLInputElement;
+      await user.type(input, "First streamed follow-up");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(mockGetConversationMessages).toHaveBeenCalledTimes(2);
+      });
+
+      await user.clear(input);
+      await user.type(input, "Second optimistic follow-up");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/error:.*fallback failed/i),
+        ).toBeInTheDocument();
+      });
+
+      resolveReconciledTranscript?.(reconciledTranscript);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Second optimistic follow-up"),
+        ).toBeInTheDocument();
+      });
     });
 
     it("loads and displays messages when conversation is selected", async () => {

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -407,6 +407,128 @@ describe("ConversationsChat", () => {
   });
 
   describe("Existing conversation flow", () => {
+    it("reconciles persisted messages after a streamed response", async () => {
+      const user = userEvent.setup({ delay: null });
+
+      const mockConversations = {
+        items: [
+          {
+            id: "conv-1",
+            title: "Existing Conversation",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const initialTranscript = {
+        conversation: mockConversations.items[0],
+        items: [
+          {
+            id: "msg-1",
+            role: "user" as const,
+            content: "Previous question",
+            sequence_number: 1,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Previous answer",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+        ],
+      };
+
+      const reconciledTranscript = {
+        conversation: mockConversations.items[0],
+        items: [
+          ...initialTranscript.items,
+          {
+            id: "persisted-user-3",
+            role: "user" as const,
+            content: "Follow-up question",
+            sequence_number: 3,
+            created_at: "2024-01-01T00:01:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "persisted-assistant-4",
+            role: "assistant" as const,
+            content: "Streamed answer",
+            sequence_number: 4,
+            created_at: "2024-01-01T00:01:02Z",
+            error: null,
+            annotations: null,
+          },
+        ],
+      };
+
+      async function* streamEvents() {
+        yield { event: "token" as const, data: "Streamed answer" };
+        yield {
+          event: "done" as const,
+          data: {
+            conversation_id: "conv-1",
+            message_id: "persisted-assistant-4",
+            content: "Streamed answer",
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+            },
+          },
+        };
+      }
+
+      mockListConversations.mockResolvedValue(mockConversations);
+      mockGetConversationMessages
+        .mockResolvedValueOnce(initialTranscript)
+        .mockResolvedValueOnce(reconciledTranscript);
+      mockStreamConversation.mockReturnValueOnce(streamEvents());
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(screen.getByText("Existing Conversation")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Existing Conversation"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Previous question")).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(/type your message/i);
+      await user.type(input, "Follow-up question");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(mockStreamConversation).toHaveBeenCalledWith(
+          "conv-1",
+          "Follow-up question",
+          expect.objectContaining({
+            signal: expect.any(AbortSignal),
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockGetConversationMessages).toHaveBeenCalledTimes(2);
+      });
+      expect(mockGetConversationMessages).toHaveBeenNthCalledWith(2, "conv-1");
+      expect(screen.getByText("Streamed answer")).toBeInTheDocument();
+      expect(screen.getByText("Follow-up question")).toBeInTheDocument();
+    });
+
     it("loads and displays messages when conversation is selected", async () => {
       const user = userEvent.setup();
 

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -20,6 +20,52 @@ interface ConversationsChatProps {
   onLogout: () => void;
 }
 
+function compareMessages(a: Message, b: Message): number {
+  const aPersisted = a.sequence_number >= 0;
+  const bPersisted = b.sequence_number >= 0;
+
+  if (aPersisted !== bPersisted) {
+    return aPersisted ? -1 : 1;
+  }
+
+  if (aPersisted && bPersisted && a.sequence_number !== b.sequence_number) {
+    return a.sequence_number - b.sequence_number;
+  }
+
+  return a.created_at.localeCompare(b.created_at);
+}
+
+function mergeTranscriptMessages(
+  transcriptMessages: Message[],
+  currentMessages: Message[],
+): Message[] {
+  const merged = [...transcriptMessages];
+  const seenIds = new Set(merged.map((message) => message.id));
+
+  for (const message of currentMessages) {
+    const isTempMessage = message.id.startsWith("temp-");
+    const hasPersistedEquivalent =
+      isTempMessage &&
+      transcriptMessages.some(
+        (transcriptMessage) =>
+          transcriptMessage.role === message.role &&
+          transcriptMessage.content === message.content,
+      );
+
+    if (hasPersistedEquivalent) {
+      continue;
+    }
+
+    if (!seenIds.has(message.id)) {
+      merged.push(message);
+      seenIds.add(message.id);
+    }
+  }
+
+  merged.sort(compareMessages);
+  return merged;
+}
+
 // Check if annotations have displayable content
 function hasAnnotationContent(annotations: AssistantAnnotations): boolean {
   return (
@@ -402,6 +448,8 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     startedWithoutActiveConversation: boolean;
   } | null>(null);
   const streamFailedRef = useRef(false);
+  const streamSucceededRef = useRef(false);
+  const reconcileRequestIdRef = useRef(0);
 
   // Get user from authState (it should always be present when component is mounted)
   const user = authState.status === "authenticated" ? authState.user : null;
@@ -494,14 +542,25 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
         pendingStreamMetaRef.current?.startedWithoutActiveConversation ?? false;
 
       if (startedWithoutActiveConversation) {
+        streamSucceededRef.current = true;
+        setInputMessage("");
         setActiveConversationId(doneData.conversation_id);
       } else {
+        const reconcileRequestId = ++reconcileRequestIdRef.current;
         void (async () => {
           try {
             const transcript = await getConversationMessages(
               doneData.conversation_id,
             );
-            setMessages(transcript.items);
+            if (reconcileRequestIdRef.current !== reconcileRequestId) {
+              return;
+            }
+
+            streamSucceededRef.current = true;
+            setMessages((prev) =>
+              mergeTranscriptMessages(transcript.items, prev),
+            );
+            setInputMessage("");
           } catch (err) {
             if (err instanceof Error && err.message === "UNAUTHORIZED") {
               onLogout();
@@ -520,6 +579,7 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
       onDone: handleStreamDone,
       onError: (streamError) => {
         streamFailedRef.current = true;
+        streamSucceededRef.current = false;
         pendingStreamMetaRef.current = null;
         if (streamError.message === "UNAUTHORIZED") {
           onLogout();
@@ -611,6 +671,8 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
   const handleNewChat = useCallback(() => {
     stop();
     reset();
+    reconcileRequestIdRef.current += 1;
+    streamSucceededRef.current = false;
     setActiveConversationId(null);
     setMessages([]);
     setError(null);
@@ -621,6 +683,8 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     (conversationId: string) => {
       stop();
       reset();
+      reconcileRequestIdRef.current += 1;
+      streamSucceededRef.current = false;
       setActiveConversationId(conversationId);
       setError(null);
     },
@@ -670,6 +734,7 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     setSendingMessage(true);
     setError(null);
     streamFailedRef.current = false;
+    streamSucceededRef.current = false;
 
     try {
       const userMessage: Message = {
@@ -686,7 +751,6 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
       } else {
         setMessages([userMessage]);
       }
-      setInputMessage("");
 
       pendingStreamMetaRef.current = {
         startedWithoutActiveConversation: !activeConversationId,
@@ -694,6 +758,9 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
 
       // Primary path: stream incremental assistant output.
       await stream(activeConversationId, trimmedMessage, {});
+      if (!streamFailedRef.current && streamSucceededRef.current) {
+        setInputMessage("");
+      }
 
       // Fallback path for environments or flows where streaming fails.
       if (streamFailedRef.current) {
@@ -723,6 +790,8 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
           setMessages([response.user_message, response.assistant_message]);
           setActiveConversationId(response.conversation.id);
         }
+
+        setInputMessage("");
       }
     } catch (err) {
       if (err instanceof Error) {

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -490,13 +490,29 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
         ];
       });
 
-      if (pendingStreamMetaRef.current?.startedWithoutActiveConversation) {
+      const startedWithoutActiveConversation =
+        pendingStreamMetaRef.current?.startedWithoutActiveConversation ?? false;
+
+      if (startedWithoutActiveConversation) {
         setActiveConversationId(doneData.conversation_id);
+      } else {
+        void (async () => {
+          try {
+            const transcript = await getConversationMessages(
+              doneData.conversation_id,
+            );
+            setMessages(transcript.items);
+          } catch (err) {
+            if (err instanceof Error && err.message === "UNAUTHORIZED") {
+              onLogout();
+            }
+          }
+        })();
       }
       pendingStreamMetaRef.current = null;
       void refreshConversations();
     },
-    [refreshConversations],
+    [onLogout, refreshConversations],
   );
 
   const { isStreaming, currentMessage, stream, stop, reset } =
@@ -681,13 +697,6 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
 
       // Fallback path for environments or flows where streaming fails.
       if (streamFailedRef.current) {
-        console.debug(
-          "[streaming] stream failed; falling back to non-stream endpoint",
-          {
-            activeConversationId,
-            messageLength: trimmedMessage.length,
-          },
-        );
         setError(null);
         if (activeConversationId) {
           const response = await addMessageToConversation(

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type {
   ConversationSummary,
   Message,
-  ConversationWithMessagesResponse,
   AssistantAnnotations,
   FailureAnnotation,
+  StreamDoneData,
 } from "../types/api";
 import {
   listConversations,
@@ -14,22 +14,10 @@ import {
 } from "../lib/api";
 import { useAuth } from "../lib/auth";
 import { MarkdownContent } from "./MarkdownContent";
+import { useStreamingConversation } from "../hooks/useStreamingConversation";
 
 interface ConversationsChatProps {
   onLogout: () => void;
-}
-
-// Create a pending assistant placeholder message with a unique ID
-function createPendingAssistantMessage(pendingId: string): Message {
-  return {
-    id: pendingId,
-    role: "assistant",
-    content: "Thinking...",
-    sequence_number: -1, // Placeholder sequence
-    created_at: new Date().toISOString(),
-    error: null,
-    annotations: null,
-  };
 }
 
 // Check if annotations have displayable content
@@ -410,6 +398,10 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
 
   // Track conversations for which we've just set messages to skip redundant fetches
   const skipFetchForConversation = useRef<string | null>(null);
+  const pendingStreamMetaRef = useRef<{
+    startedWithoutActiveConversation: boolean;
+  } | null>(null);
+  const streamFailedRef = useRef(false);
 
   // Get user from authState (it should always be present when component is mounted)
   const user = authState.status === "authenticated" ? authState.user : null;
@@ -465,6 +457,61 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [selectedMessageId, handleCloseDetails]);
+
+  const refreshConversations = useCallback(async () => {
+    try {
+      const response = await listConversations();
+      setConversations(response.items);
+    } catch (err) {
+      if (err instanceof Error && err.message === "UNAUTHORIZED") {
+        onLogout();
+      }
+    }
+  }, [onLogout]);
+
+  const handleStreamDone = useCallback(
+    (doneData: StreamDoneData) => {
+      setMessages((prev) => {
+        const nextSequence =
+          prev.length > 0
+            ? Math.max(...prev.map((msg) => msg.sequence_number)) + 1
+            : 0;
+        return [
+          ...prev,
+          {
+            id: doneData.message_id,
+            role: "assistant",
+            content: doneData.content,
+            sequence_number: nextSequence,
+            created_at: new Date().toISOString(),
+            error: null,
+            annotations: doneData.annotations,
+          },
+        ];
+      });
+
+      if (pendingStreamMetaRef.current?.startedWithoutActiveConversation) {
+        setActiveConversationId(doneData.conversation_id);
+      }
+      pendingStreamMetaRef.current = null;
+      void refreshConversations();
+    },
+    [refreshConversations],
+  );
+
+  const { isStreaming, currentMessage, stream, stop, reset } =
+    useStreamingConversation({
+      onDone: handleStreamDone,
+      onError: (streamError) => {
+        streamFailedRef.current = true;
+        pendingStreamMetaRef.current = null;
+        if (streamError.message === "UNAUTHORIZED") {
+          onLogout();
+          return;
+        }
+        setError(streamError.message);
+      },
+    });
 
   // Load conversations on mount
   useEffect(() => {
@@ -546,20 +593,31 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
 
   // Handle new chat button
   const handleNewChat = useCallback(() => {
+    stop();
+    reset();
     setActiveConversationId(null);
     setMessages([]);
     setError(null);
-  }, []);
+  }, [reset, stop]);
 
   // Handle conversation selection
-  const handleSelectConversation = useCallback((conversationId: string) => {
-    setActiveConversationId(conversationId);
-    setError(null);
-  }, []);
+  const handleSelectConversation = useCallback(
+    (conversationId: string) => {
+      stop();
+      reset();
+      setActiveConversationId(conversationId);
+      setError(null);
+    },
+    [reset, stop],
+  );
 
   // Update conversations list with new or updated conversation
   const updateConversationsList = useCallback(
-    (conversationResponse: ConversationWithMessagesResponse) => {
+    (conversationResponse: {
+      conversation: ConversationSummary;
+      user_message: Message;
+      assistant_message: Message;
+    }) => {
       const { conversation } = conversationResponse;
       setConversations((prev) => {
         const existing = prev.find((c) => c.id === conversation.id);
@@ -591,104 +649,70 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     if (!trimmedMessage) return;
 
     // Guard against concurrent sends while request is in flight
-    if (sendingMessage) return;
+    if (sendingMessage || isStreaming) return;
 
     setSendingMessage(true);
     setError(null);
-
-    // Generate unique pending message ID for this send attempt
-    const pendingId = crypto.randomUUID();
+    streamFailedRef.current = false;
 
     try {
-      let response: ConversationWithMessagesResponse;
-
+      const userMessage: Message = {
+        id: `temp-user-${Date.now()}`,
+        role: "user",
+        content: trimmedMessage,
+        sequence_number: activeConversationId ? -1 : 1,
+        created_at: new Date().toISOString(),
+        error: null,
+        annotations: null,
+      };
       if (activeConversationId) {
-        // Add message to existing conversation
-        // Immediately show user message and pending assistant placeholder
-        const userMessage: Message = {
-          id: `temp-user-${Date.now()}`,
-          role: "user",
-          content: trimmedMessage,
-          sequence_number: -1,
-          created_at: new Date().toISOString(),
-          error: null,
-          annotations: null,
-        };
-        const pendingMessage = createPendingAssistantMessage(pendingId);
-        setMessages((prev) => [...prev, userMessage, pendingMessage]);
+        setMessages((prev) => [...prev, userMessage]);
+      } else {
+        setMessages([userMessage]);
+      }
+      setInputMessage("");
 
-        try {
-          response = await addMessageToConversation(activeConversationId, {
-            content: trimmedMessage,
-          });
+      pendingStreamMetaRef.current = {
+        startedWithoutActiveConversation: !activeConversationId,
+      };
 
-          // Replace pending placeholder with real assistant message AND replace optimistic user message with persisted version
-          setMessages((prev) =>
-            prev.map((msg) => {
-              if (msg.id === pendingId) {
-                return response.assistant_message;
-              }
-              if (msg.id === userMessage.id && response.user_message) {
-                return response.user_message;
-              }
-              return msg;
-            }),
+      // Primary path: stream incremental assistant output.
+      await stream(activeConversationId, trimmedMessage, {});
+
+      // Fallback path for environments or flows where streaming fails.
+      if (streamFailedRef.current) {
+        console.debug(
+          "[streaming] stream failed; falling back to non-stream endpoint",
+          {
+            activeConversationId,
+            messageLength: trimmedMessage.length,
+          },
+        );
+        setError(null);
+        if (activeConversationId) {
+          const response = await addMessageToConversation(
+            activeConversationId,
+            {
+              content: trimmedMessage,
+            },
           );
 
-          // Update conversations list
-          updateConversationsList(response);
-
-          // Clear input only on success
-          setInputMessage("");
-        } catch (err) {
-          // Remove both pending message and optimistic user message on error
-          // Keep input text so user can retry
           setMessages((prev) =>
-            prev.filter(
-              (msg) => msg.id !== pendingId && msg.id !== userMessage.id,
+            prev.map((msg) =>
+              msg.id === userMessage.id ? response.user_message : msg,
             ),
           );
-          throw err;
-        }
-      } else {
-        // Create new conversation with message
-        // Immediately show user message and pending placeholder
-        const userMessage: Message = {
-          id: `temp-user-${Date.now()}`,
-          role: "user",
-          content: trimmedMessage,
-          sequence_number: 1,
-          created_at: new Date().toISOString(),
-          error: null,
-          annotations: null,
-        };
-        const pendingMessage = createPendingAssistantMessage(pendingId);
-        setMessages([userMessage, pendingMessage]);
-
-        try {
-          response = await createConversationWithMessage({
+          setMessages((prev) => [...prev, response.assistant_message]);
+          updateConversationsList(response);
+        } else {
+          const response = await createConversationWithMessage({
             content: trimmedMessage,
           });
 
-          // Update conversations list
           updateConversationsList(response);
-
-          // Mark this conversation to skip the initial fetch
           skipFetchForConversation.current = response.conversation.id;
-
-          // Set messages with real user and assistant messages, removing placeholder
           setMessages([response.user_message, response.assistant_message]);
-
-          // Set active conversation to the new one (this will trigger useEffect but it will skip fetch)
           setActiveConversationId(response.conversation.id);
-
-          // Clear input only on success
-          setInputMessage("");
-        } catch (err) {
-          // Remove fake optimistic messages if API call fails
-          // Keep input text so user can retry
-          setMessages([]);
-          throw err;
         }
       }
     } catch (err) {
@@ -712,6 +736,9 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
       handleSendMessage();
     }
   };
+
+  const messagesToRender =
+    isStreaming && currentMessage ? [...messages, currentMessage] : messages;
 
   return (
     <div className="flex h-screen bg-gray-100">
@@ -797,13 +824,13 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
         <div className="flex-1 flex overflow-hidden">
           {/* Messages area */}
           <div className="flex-1 overflow-y-auto p-4">
-            {activeConversationId ? (
+            {activeConversationId || messagesToRender.length > 0 ? (
               <>
                 {transcriptLoading && messages.length === 0 ? (
                   <div className="text-gray-500">Loading messages...</div>
                 ) : (
                   <div className="space-y-4 max-w-3xl mx-auto">
-                    {messages.map((msg) => (
+                    {messagesToRender.map((msg) => (
                       <div
                         key={msg.id}
                         className={`flex ${
@@ -818,14 +845,25 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
                                 ? "message-user-bubble"
                                 : msg.error
                                   ? "message-error-bubble"
-                                  : msg.role === "assistant" &&
-                                      msg.sequence_number === -1
-                                    ? "message-pending-bubble"
+                                  : msg.id.startsWith("streaming-")
+                                    ? "message-streaming-bubble"
                                     : "message-assistant-bubble"
                             }`}
                           >
                             {msg.role === "assistant" ? (
-                              <MarkdownContent content={msg.content} />
+                              <>
+                                {msg.annotations?.thought && (
+                                  <div className="thought-trace">
+                                    <div className="thought-trace-label">
+                                      Thought trace
+                                    </div>
+                                    <div className="thought-trace-content">
+                                      {msg.annotations.thought}
+                                    </div>
+                                  </div>
+                                )}
+                                <MarkdownContent content={msg.content} />
+                              </>
                             ) : (
                               <div className="whitespace-pre-wrap">
                                 {msg.content}

--- a/apps/assistant-ui/src/index.css
+++ b/apps/assistant-ui/src/index.css
@@ -187,6 +187,33 @@
     font-family: var(--font-sans);
   }
 
+  .message-streaming-bubble {
+    @apply bg-[#fbf8f2] text-[#1f1c18] px-4 py-2 rounded-lg border border-[#c9bfae];
+    font-family: var(--font-sans);
+  }
+
+  .thought-trace {
+    @apply mb-2 px-3 py-2 rounded border-l-2 border-[#c9bfae] bg-[#f6f2ea];
+  }
+
+  .thought-trace-label {
+    @apply mb-1;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  .thought-trace-content {
+    @apply whitespace-pre-wrap;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-text-muted);
+  }
+
   /* Trust metadata row */
   .trust-row {
     @apply flex flex-wrap gap-3 mt-2 pt-2 border-t border-[#ded6c7];

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -154,6 +154,39 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
 - **PR 6:** Integrate the streaming hook into the main Chat UI and add styling for
   thought traces.
 
+### Phase 7: Streaming Tool Loop (Backend + Frontend)
+- **PR 7:** Implement true tool execution during streaming turns (not just `tool_call`
+  event emission), including:
+  - Execute tool calls emitted by the streaming LLM response.
+  - Feed tool results back into the LLM and continue streaming assistant output.
+  - Persist executed tool metadata in annotations for the final assistant message.
+  - Emit reliable `tool_call` lifecycle events (`requested`, `running`, `completed`,
+    `failed`) so the UI can show truthful state.
+  - Keep persistence guarantees: user message immediate, assistant message deferred to
+    terminal state.
+
+## Current Status & Remaining Gaps
+
+The current implementation supports token/thought streaming and persistence lifecycle,
+but it is not yet complete relative to the product goals. Remaining work:
+
+- **Streaming tool execution is incomplete:** tool calls detected during streaming are
+  not yet executed in-stream.
+- **Fallback behavior masks failures:** UI fallback from stream to non-stream can hide
+  stream-path bugs and produce confusing duplicate failures.
+- **Token-limit handling needs operator controls:** truncation (`finish_reason=length`)
+  is observable, but default limits and user-facing behavior for truncation recovery
+  need to be finalized.
+- **End-to-end test coverage gaps:** add backend router/service tests and frontend
+  integration tests for:
+  - streaming with tool calls
+  - interrupted streams with partial assistant output
+  - terminal error handling without silent fallback
+  - `done` payload integrity (message id, annotations, usage when available)
+- **Operational guidance:** document model/endpoint requirements (OpenAI-compatible
+  `/v1/chat/completions`) and expected behavior when backend/model does not support the
+  configured path.
+
 ## Testing Strategy
 
 - **Backend:** Mock LLM streams and verify SSE event sequence.


### PR DESCRIPTION
## Summary
- reconcile streamed responses in existing conversations by refreshing transcript on stream completion
- remove frontend stream fallback console debug noise
- add regression test for persisted transcript reconciliation after streaming
- revert unintended settings.py delta so no settings changes remain versus main
- remove unused local assignment in conversation service streaming path
 
## Validation
### Backend (run locally)
- uv run ruff check src/ tests/
- uv run pyrefly check src/
- uv run pytest -v
 
### Frontend
- ./node_modules/.bin/prettier --write .
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/tsc --noEmit
- npm run test (user-reported: 105 passed)
 
