### PR TITLE
Add in-stream tool execution for streaming responses

### DIFF
--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -27,7 +27,6 @@ from assistant.models.llm import (
     ChatCompletionRequestSystemMessage,
     LLMCompletionError,
     LLMCompletionErrorKind,
-    StreamParserOutput,
     ToolChoice,
 )
 from assistant.models.tool import ToolExecutionResult
@@ -515,6 +514,8 @@ class ConversationService:
         )
         content_parts: list[str] = []
         thought_parts: list[str] = []
+        executed_tools: list[ToolExecutionResult] = []
+        attempted_tool_execution = False
         model_name: str | None = None
         usage_payload: dict | None = None
         stream_started = False
@@ -523,27 +524,48 @@ class ConversationService:
         emitted_tool_calls = 0
 
         try:
-            async for output in self._call_llm_chat_completion_stream(
+            async for event in self._call_llm_chat_completion_stream(
                 messages=context_messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
             ):
-                if output.thought:
-                    thought_parts.append(output.thought)
+                event_type = event['type']
+                if event_type == 'thought':
+                    thought = cast(str, event['data'])
+                    thought_parts.append(thought)
                     stream_started = True
                     emitted_thoughts += 1
-                    yield SSEEncoder.encode('thought', output.thought)
+                    yield SSEEncoder.encode('thought', thought)
+                    continue
 
-                if output.token:
-                    content_parts.append(output.token)
+                if event_type == 'token':
+                    token = cast(str, event['data'])
+                    content_parts.append(token)
                     stream_started = True
                     emitted_tokens += 1
-                    yield SSEEncoder.encode('token', output.token)
+                    yield SSEEncoder.encode('token', token)
+                    continue
 
-                if output.model:
-                    model_name = output.model
-                if output.usage:
-                    usage_payload = output.usage.model_dump()
+                if event_type == 'tool_call':
+                    stream_started = True
+                    attempted_tool_execution = True
+                    emitted_tool_calls += 1
+                    yield SSEEncoder.encode('tool_call', event['data'])
+                    continue
+
+                if event_type == 'meta':
+                    if event['data'].get('model') is not None:
+                        model_name = cast(str, event['data']['model'])
+                    usage = event['data'].get('usage')
+                    if usage is not None:
+                        usage_payload = cast(dict, usage)
+                    executed_tools = cast(
+                        list[ToolExecutionResult],
+                        event['data']['executed_tools'],
+                    )
+                    attempted_tool_execution = cast(
+                        bool, event['data']['attempted_tool_execution']
+                    )
 
         except LLMCompletionError as error:
             logger.debug(
@@ -565,6 +587,8 @@ class ConversationService:
                     or 'Unable to generate a response. Please try again.',
                     thought=''.join(thought_parts) or None,
                     fact_ids=fact_ids,
+                    executed_tools=executed_tools,
+                    attempted_tool_execution=attempted_tool_execution,
                     error=error,
                 )
 
@@ -601,6 +625,8 @@ class ConversationService:
                     or 'Unable to generate a response. Please try again.',
                     thought=''.join(thought_parts) or None,
                     fact_ids=fact_ids,
+                    executed_tools=executed_tools,
+                    attempted_tool_execution=attempted_tool_execution,
                     error=cancellation_error,
                 )
             raise
@@ -613,6 +639,8 @@ class ConversationService:
             or 'Unable to generate a response. Please try again.',
             thought=''.join(thought_parts) or None,
             fact_ids=fact_ids,
+            executed_tools=executed_tools,
+            attempted_tool_execution=attempted_tool_execution,
             error=None,
         )
         logger.debug(
@@ -656,19 +684,21 @@ class ConversationService:
         content: str,
         thought: str | None,
         fact_ids: list[uuid.UUID],
+        executed_tools: list[ToolExecutionResult],
+        attempted_tool_execution: bool,
         error: LLMCompletionError | None,
     ) -> Message:
         """Persist an assistant message row for terminal stream completion."""
         if error:
             annotations_obj = self.annotation_service.build_failure_annotations(
                 error=error,
-                executed_tools=[],
-                attempted_tool_execution=False,
+                executed_tools=executed_tools,
+                attempted_tool_execution=attempted_tool_execution,
             )
             error_text = self.annotation_service.format_error_detail(error)
         else:
             annotations_obj = self.annotation_service.build_success_annotations(
-                executed_tools=[],
+                executed_tools=executed_tools,
                 fact_ids=fact_ids,
             )
             error_text = None
@@ -893,40 +923,184 @@ class ConversationService:
         messages: list[dict],
         temperature: float,
         max_tokens: int | None,
-    ) -> AsyncGenerator[StreamParserOutput, None]:
-        """Call streaming completion seam and yield parsed incremental outputs."""
+    ) -> AsyncGenerator[dict, None]:
+        """Call streaming completion seam, executing tools between stream rounds."""
         system_message = ChatCompletionRequestSystemMessage(
             role='system', content=SYSTEM_PROMPT
         )
         llm_messages = [system_message.model_dump()] + messages
+        available_tools = self.tool_service.get_available_tools()
+        tools = available_tools if available_tools else None
+        executed_tools: list[ToolExecutionResult] = []
+        attempted_tool_execution = False
 
-        completion_kwargs = {
-            'messages': llm_messages,
-            'model': settings.llm_model,
-            'temperature': temperature,
-            'max_tokens': max_tokens,
-        }
+        for _ in range(MAXIMUM_TOOL_ROUNDS):
+            round_tool_calls: list = []
+            round_content_parts: list[str] = []
 
-        async for output in self.llm_service.stream_messages(
-            **completion_kwargs
-        ):
-            if output.finish_reason is not None:
-                logger.debug(
-                    'conversation streaming turn complete: finish_reason=%s usage=%s',
-                    output.finish_reason,
-                    output.usage.model_dump() if output.usage else None,
-                )
-                if output.finish_reason == 'length':
+            completion_kwargs = {
+                'messages': llm_messages,
+                'model': settings.llm_model,
+                'temperature': temperature,
+                'max_tokens': max_tokens,
+            }
+            if tools:
+                completion_kwargs['tools'] = [
+                    tool.model_dump() for tool in tools
+                ]
+                completion_kwargs['tool_choice'] = ToolChoice.auto
+
+            async for output in self.llm_service.stream_messages(
+                **completion_kwargs
+            ):
+                if output.finish_reason is not None:
                     logger.debug(
-                        'conversation streaming turn likely truncated: max_tokens=%s',
-                        max_tokens,
+                        'conversation streaming turn complete: finish_reason=%s usage=%s',
+                        output.finish_reason,
+                        output.usage.model_dump() if output.usage else None,
                     )
-            if output.tool_calls:
-                raise LLMCompletionError(
-                    kind=LLMCompletionErrorKind.invalid_response,
-                    message='Streaming tool calls are not yet supported',
+                    if output.finish_reason == 'length':
+                        logger.debug(
+                            'conversation streaming turn likely truncated: max_tokens=%s',
+                            max_tokens,
+                        )
+
+                if output.thought:
+                    yield {'type': 'thought', 'data': output.thought}
+
+                if output.token:
+                    round_content_parts.append(output.token)
+                    yield {'type': 'token', 'data': output.token}
+
+                if output.model or output.usage:
+                    yield {
+                        'type': 'meta',
+                        'data': {
+                            'model': output.model,
+                            'usage': output.usage.model_dump()
+                            if output.usage
+                            else None,
+                            'executed_tools': executed_tools,
+                            'attempted_tool_execution': attempted_tool_execution,
+                        },
+                    }
+
+                if output.tool_calls:
+                    round_tool_calls = output.tool_calls
+
+            if not round_tool_calls:
+                yield {
+                    'type': 'meta',
+                    'data': {
+                        'executed_tools': executed_tools,
+                        'attempted_tool_execution': attempted_tool_execution,
+                    },
+                }
+                return
+
+            attempted_tool_execution = True
+            llm_messages.append(
+                {
+                    'role': 'assistant',
+                    'content': ''.join(round_content_parts) or None,
+                    'tool_calls': round_tool_calls,
+                }
+            )
+
+            for tool_call in round_tool_calls:
+                yield {
+                    'type': 'tool_call',
+                    'data': {
+                        'id': tool_call.id,
+                        'name': tool_call.function.name,
+                        'status': 'requested',
+                    },
+                }
+                parsed_arguments = self._parse_tool_arguments(tool_call)
+                yield {
+                    'type': 'tool_call',
+                    'data': {
+                        'id': tool_call.id,
+                        'name': tool_call.function.name,
+                        'status': 'running',
+                    },
+                }
+                try:
+                    tool_result = await self.tool_service.execute_tool(
+                        name=tool_call.function.name,
+                        arguments=parsed_arguments,
+                    )
+                except (UnsupportedToolError, DisabledToolError) as exc:
+                    yield {
+                        'type': 'tool_call',
+                        'data': {
+                            'id': tool_call.id,
+                            'name': tool_call.function.name,
+                            'status': 'failed',
+                            'detail': str(exc),
+                        },
+                    }
+                    raise LLMCompletionError(
+                        kind=LLMCompletionErrorKind.invalid_response,
+                        message=f'Tool error: {str(exc)}',
+                    ) from exc
+                except Exception as exc:
+                    yield {
+                        'type': 'tool_call',
+                        'data': {
+                            'id': tool_call.id,
+                            'name': tool_call.function.name,
+                            'status': 'failed',
+                            'detail': str(exc),
+                        },
+                    }
+                    raise LLMCompletionError(
+                        kind=LLMCompletionErrorKind.backend_error,
+                        message=f'Error executing tool {tool_call.function.name}: {str(exc)}',
+                    ) from exc
+
+                executed_tools.append(tool_result)
+                yield {
+                    'type': 'tool_call',
+                    'data': {
+                        'id': tool_call.id,
+                        'name': tool_call.function.name,
+                        'status': 'completed'
+                        if tool_result.status.value == 'success'
+                        else 'failed',
+                    },
+                }
+
+                llm_messages.append(
+                    {
+                        'role': 'tool',
+                        'tool_call_id': tool_call.id,
+                        'content': tool_result.llm_context or '',
+                    }
                 )
-            yield output
+
+        raise LLMCompletionError(
+            kind=LLMCompletionErrorKind.backend_error,
+            message=f'Assistant exceeded maximum tool rounds ({MAXIMUM_TOOL_ROUNDS})',
+        )
+
+    @staticmethod
+    def _parse_tool_arguments(
+        tool_call,
+    ) -> dict:
+        """Parse tool arguments from an OpenAI-compatible tool call delta."""
+        try:
+            parsed_arguments = json.loads(tool_call.function.arguments)
+            if not isinstance(parsed_arguments, dict):
+                raise ValueError(
+                    f'Tool arguments must be a JSON object, got {type(parsed_arguments).__name__}'
+                )
+            return parsed_arguments
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise LLMCompletionError(
+                kind=LLMCompletionErrorKind.invalid_response,
+                message=f'Unable to parse tool arguments for {tool_call.function.name}: {str(exc)}',
+            ) from exc
 
     @staticmethod
     def _conversation_summary(

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -24,6 +24,7 @@ from assistant.models.conversation import (
 )
 from assistant.models.conversation_sql import Conversation, Message
 from assistant.models.llm import (
+    ChatCompletionMessageToolCall,
     ChatCompletionRequestSystemMessage,
     LLMCompletionError,
     LLMCompletionErrorKind,
@@ -935,7 +936,7 @@ class ConversationService:
         attempted_tool_execution = False
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
-            round_tool_calls: dict[str, object] = {}
+            round_tool_calls: dict[str, ChatCompletionMessageToolCall] = {}
             round_content_parts: list[str] = []
 
             completion_kwargs = {

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -1070,6 +1070,13 @@ class ConversationService:
                         else 'failed',
                     },
                 }
+                yield {
+                    'type': 'meta',
+                    'data': {
+                        'executed_tools': executed_tools,
+                        'attempted_tool_execution': attempted_tool_execution,
+                    },
+                }
 
                 llm_messages.append(
                     {

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -935,7 +935,7 @@ class ConversationService:
         attempted_tool_execution = False
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
-            round_tool_calls: list = []
+            round_tool_calls: dict[str, object] = {}
             round_content_parts: list[str] = []
 
             completion_kwargs = {
@@ -986,7 +986,8 @@ class ConversationService:
                     }
 
                 if output.tool_calls:
-                    round_tool_calls = output.tool_calls
+                    for tool_call in output.tool_calls:
+                        round_tool_calls[tool_call.id] = tool_call
 
             if not round_tool_calls:
                 yield {
@@ -1003,11 +1004,11 @@ class ConversationService:
                 {
                     'role': 'assistant',
                     'content': ''.join(round_content_parts) or None,
-                    'tool_calls': round_tool_calls,
+                    'tool_calls': list(round_tool_calls.values()),
                 }
             )
 
-            for tool_call in round_tool_calls:
+            for tool_call in round_tool_calls.values():
                 yield {
                     'type': 'tool_call',
                     'data': {
@@ -1016,7 +1017,19 @@ class ConversationService:
                         'status': 'requested',
                     },
                 }
-                parsed_arguments = self._parse_tool_arguments(tool_call)
+                try:
+                    parsed_arguments = self._parse_tool_arguments(tool_call)
+                except LLMCompletionError as exc:
+                    yield {
+                        'type': 'tool_call',
+                        'data': {
+                            'id': tool_call.id,
+                            'name': tool_call.function.name,
+                            'status': 'failed',
+                            'detail': str(exc),
+                        },
+                    }
+                    raise
                 yield {
                     'type': 'tool_call',
                     'data': {

--- a/apps/assistant-backend/tests/services/conversation/test_conversation_annotations.py
+++ b/apps/assistant-backend/tests/services/conversation/test_conversation_annotations.py
@@ -18,7 +18,7 @@ from assistant.models.conversation import (
 from assistant.models.conversation_sql import Conversation, Message
 from assistant.models.llm import (
     LLMCompletionError,
-     LLMCompletionErrorKind,
+    LLMCompletionErrorKind,
     LLMCompletionResult,
 )
 from assistant.services.assistant_annotations import AssistantAnnotationService

--- a/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
+++ b/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
@@ -232,7 +232,7 @@ async def test_add_message_to_conversation_stream_skips_assistant_persistence_wi
 
 
 @pytest.mark.asyncio
-async def test_add_message_to_conversation_stream_errors_on_tool_calls(
+async def test_add_message_to_conversation_stream_executes_tool_calls(
     conversation_service,
     mock_llm_service,
     mock_context_assembly,
@@ -341,6 +341,114 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
 
 
 @pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_executes_tool_calls_across_deltas(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    mock_tool_service,
+    async_session,
+    test_user_id,
+):
+    """Streaming path accumulates tool calls across multiple deltas in one round."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Multi Tool'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger multiple tool calls'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def first_round():
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_1',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='{}'
+                    ),
+                )
+            ]
+        )
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_2',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='{}'
+                    ),
+                )
+            ]
+        )
+
+    async def second_round():
+        yield StreamParserOutput(token='Done', finish_reason='stop')
+
+    mock_llm_service.stream_messages = Mock(
+        side_effect=[first_round(), second_round()]
+    )
+    mock_tool_service.execute_tool.side_effect = [
+        ToolExecutionResult(
+            tool_name='current_time',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call={
+                'name': 'current_time',
+                'arguments': {},
+                'started_at': datetime.now(timezone.utc),
+                'finished_at': datetime.now(timezone.utc),
+                'status': ToolExecutionStatus.SUCCESS,
+            },
+            llm_context='First result',
+        ),
+        ToolExecutionResult(
+            tool_name='current_time',
+            status=ToolExecutionStatus.SUCCESS,
+            tool_call={
+                'name': 'current_time',
+                'arguments': {},
+                'started_at': datetime.now(timezone.utc),
+                'finished_at': datetime.now(timezone.utc),
+                'status': ToolExecutionStatus.SUCCESS,
+            },
+            llm_context='Second result',
+        ),
+    ]
+
+    payload = CreateMessageRequest(content='Trigger multiple tool calls')
+
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    assert mock_tool_service.execute_tool.call_count == 2
+    tool_events = [
+        json.loads(event.split('data: ', 1)[1].strip())
+        for event in emitted_events
+        if event.startswith('event: tool_call')
+    ]
+    assert [tool_event['status'] for tool_event in tool_events] == [
+        'requested',
+        'running',
+        'completed',
+        'requested',
+        'running',
+        'completed',
+    ]
+
+
+@pytest.mark.asyncio
 async def test_add_message_to_conversation_stream_emits_failed_tool_lifecycle(
     conversation_service,
     mock_llm_service,
@@ -419,6 +527,72 @@ async def test_add_message_to_conversation_stream_emits_failed_tool_lifecycle(
     assert persisted_messages[1].role == 'assistant'
     assert persisted_messages[1].content == 'Trying '
     assert persisted_messages[1].annotations['failure']['stage'] == 'tool'
+
+
+@pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_emits_failed_tool_lifecycle_for_invalid_arguments(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """Invalid tool arguments emit a failed lifecycle event before terminal error."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Tool Parse Failure'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger parse failure'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_bad_args',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='[]'
+                    ),
+                )
+            ]
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Trigger parse failure')
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    tool_events = [
+        json.loads(event.split('data: ', 1)[1].strip())
+        for event in emitted_events
+        if event.startswith('event: tool_call')
+    ]
+    assert [tool_event['status'] for tool_event in tool_events] == [
+        'requested',
+        'failed',
+    ]
+    assert 'json object' in tool_events[-1]['detail'].lower()
+
+    error_event = next(
+        event for event in emitted_events if event.startswith('event: error')
+    )
+    error_payload = json.loads(error_event.split('data: ', 1)[1].strip())
+    assert 'parse tool arguments' in error_payload['detail'].lower()
 
 
 @pytest.mark.asyncio

--- a/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
+++ b/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
@@ -474,6 +474,92 @@ async def test_add_message_to_conversation_stream_persists_partial_on_cancellati
 
 
 @pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_persists_executed_tools_on_cancellation(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    mock_tool_service,
+    async_session,
+    test_user_id,
+):
+    """Cancellation after a successful tool run still persists tool metadata."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Cancellation With Tool'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[
+            {'role': 'user', 'content': 'Trigger cancellation after tool'}
+        ],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def first_round():
+        yield StreamParserOutput(token='Checking ')
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_cancel',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='{}'
+                    ),
+                )
+            ]
+        )
+
+    async def second_round():
+        raise asyncio.CancelledError()
+        yield  # pragma: no cover
+
+    mock_llm_service.stream_messages = Mock(
+        side_effect=[first_round(), second_round()]
+    )
+    mock_tool_service.execute_tool.return_value = ToolExecutionResult(
+        tool_name='current_time',
+        status=ToolExecutionStatus.SUCCESS,
+        tool_call={
+            'name': 'current_time',
+            'arguments': {},
+            'started_at': datetime.now(timezone.utc),
+            'finished_at': datetime.now(timezone.utc),
+            'status': ToolExecutionStatus.SUCCESS,
+        },
+        llm_context='The current time is 10:00.',
+    )
+
+    payload = CreateMessageRequest(content='Trigger cancellation after tool')
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in conversation_service.add_message_to_conversation_stream(
+            session=async_session,
+            user_id=test_user_id,
+            conversation_id=conversation.id,
+            payload=payload,
+        ):
+            pass
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Checking '
+    assert persisted_messages[1].annotations['tools'] == [
+        {'id': None, 'name': 'current_time', 'status': 'completed'}
+    ]
+    assert persisted_messages[1].annotations['failure']['stage'] == 'tool'
+
+
+@pytest.mark.asyncio
 async def test_create_conversation_with_message_stream_persists_lifecycle_success(
     conversation_service,
     mock_llm_service,

--- a/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
+++ b/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
@@ -1,6 +1,7 @@
 """Tests for ConversationService streaming operations."""
 
 import asyncio
+from datetime import datetime, timezone
 import json
 from unittest.mock import Mock
 
@@ -20,6 +21,7 @@ from assistant.models.llm import (
     LLMCompletionErrorKind,
     StreamParserOutput,
 )
+from assistant.models.tool import ToolExecutionResult, ToolExecutionStatus
 from assistant.services.context_assembly import ContextAssemblyResult
 
 
@@ -234,10 +236,11 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
     conversation_service,
     mock_llm_service,
     mock_context_assembly,
+    mock_tool_service,
     async_session,
     test_user_id,
 ):
-    """Streaming path emits terminal error when model returns tool calls."""
+    """Streaming path executes tool calls and continues the assistant turn."""
     conversation = Conversation(user_id=test_user_id, title='Streaming Tool')
     async_session.add(conversation)
     await async_session.commit()
@@ -250,7 +253,8 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
         fact_ids=[],
     )
 
-    async def stream_outputs():
+    async def first_round():
+        yield StreamParserOutput(token='Checking ')
         yield StreamParserOutput(
             tool_calls=[
                 ChatCompletionMessageToolCall(
@@ -263,7 +267,33 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
             ]
         )
 
-    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+    async def second_round():
+        yield StreamParserOutput(
+            token='the current time.',
+            finish_reason='stop',
+            usage=CompletionUsage(
+                prompt_tokens=8,
+                completion_tokens=5,
+                total_tokens=13,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(
+        side_effect=[first_round(), second_round()]
+    )
+    mock_tool_service.execute_tool.return_value = ToolExecutionResult(
+        tool_name='current_time',
+        status=ToolExecutionStatus.SUCCESS,
+        tool_call={
+            'name': 'current_time',
+            'arguments': {},
+            'started_at': datetime.now(timezone.utc),
+            'finished_at': datetime.now(timezone.utc),
+            'status': ToolExecutionStatus.SUCCESS,
+        },
+        llm_context='The current time is 10:00.',
+    )
 
     payload = CreateMessageRequest(content='Trigger tool call')
     emitted_events = []
@@ -275,10 +305,26 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
     ):
         emitted_events.append(event)
 
-    assert len(emitted_events) == 1
-    assert emitted_events[0].startswith('event: error')
-    error_payload = json.loads(emitted_events[0].split('data: ', 1)[1].strip())
-    assert 'not yet supported' in error_payload['detail'].lower()
+    assert any(event.startswith('event: token') for event in emitted_events)
+    tool_events = [
+        json.loads(event.split('data: ', 1)[1].strip())
+        for event in emitted_events
+        if event.startswith('event: tool_call')
+    ]
+    assert [tool_event['status'] for tool_event in tool_events] == [
+        'requested',
+        'running',
+        'completed',
+    ]
+    assert tool_events[-1]['name'] == 'current_time'
+    done_event = next(
+        event for event in emitted_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['content'] == 'Checking the current time.'
+    assert done_payload['annotations']['tools'] == [
+        {'id': None, 'name': 'current_time', 'status': 'completed'}
+    ]
 
     result = await async_session.execute(
         select(Message)
@@ -286,8 +332,93 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
         .order_by(Message.sequence_number.asc())
     )
     persisted_messages = list(result.scalars().all())
-    assert len(persisted_messages) == 1
-    assert persisted_messages[0].role == 'user'
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Checking the current time.'
+    assert persisted_messages[1].annotations['tools'] == [
+        {'id': None, 'name': 'current_time', 'status': 'completed'}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_emits_failed_tool_lifecycle(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    mock_tool_service,
+    async_session,
+    test_user_id,
+):
+    """Streaming path persists a terminal tool error with tool lifecycle metadata."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Streaming Tool Failure'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Trigger tool failure'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='Trying ')
+        yield StreamParserOutput(
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id='call_fail',
+                    type='function',
+                    function=ChatCompletionMessageToolCallFunction(
+                        name='current_time', arguments='{}'
+                    ),
+                )
+            ]
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+    mock_tool_service.execute_tool.side_effect = RuntimeError('tool exploded')
+
+    payload = CreateMessageRequest(content='Trigger tool failure')
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    tool_events = [
+        json.loads(event.split('data: ', 1)[1].strip())
+        for event in emitted_events
+        if event.startswith('event: tool_call')
+    ]
+    assert [tool_event['status'] for tool_event in tool_events] == [
+        'requested',
+        'running',
+        'failed',
+    ]
+    assert tool_events[-1]['detail'] == 'tool exploded'
+
+    error_event = next(
+        event for event in emitted_events if event.startswith('event: error')
+    )
+    error_payload = json.loads(error_event.split('data: ', 1)[1].strip())
+    assert 'tool exploded' in error_payload['detail'].lower()
+
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Trying '
+    assert persisted_messages[1].annotations['failure']['stage'] == 'tool'
 
 
 @pytest.mark.asyncio

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -22,6 +22,7 @@ from assistant.models.llm import (
     LLMCompletionErrorKind,
     StreamParserOutput,
 )
+from assistant.models.tool import ToolExecutionResult, ToolExecutionStatus
 from assistant.services.assistant_annotations import AssistantAnnotationService
 from assistant.services.context_assembly import (
     ContextAssemblyResult,
@@ -818,10 +819,11 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
     conversation_service,
     mock_llm_service,
     mock_context_assembly,
+    mock_tool_service,
     async_session,
     test_user_id,
 ):
-    """Streaming path emits terminal error when model returns tool calls."""
+    """Streaming path executes tool calls and completes the assistant turn."""
     conversation = Conversation(user_id=test_user_id, title='Streaming Tool')
     async_session.add(conversation)
     await async_session.commit()
@@ -835,6 +837,7 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
     )
 
     async def stream_outputs():
+        yield StreamParserOutput(token='Checking ')
         yield StreamParserOutput(
             tool_calls=[
                 ChatCompletionMessageToolCall(
@@ -847,7 +850,33 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
             ]
         )
 
-    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+    async def final_outputs():
+        yield StreamParserOutput(
+            token='the current time.',
+            finish_reason='stop',
+            usage=CompletionUsage(
+                prompt_tokens=8,
+                completion_tokens=5,
+                total_tokens=13,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(
+        side_effect=[stream_outputs(), final_outputs()]
+    )
+    mock_tool_service.execute_tool.return_value = ToolExecutionResult(
+        tool_name='current_time',
+        status=ToolExecutionStatus.SUCCESS,
+        tool_call={
+            'name': 'current_time',
+            'arguments': {},
+            'started_at': datetime.now(timezone.utc),
+            'finished_at': datetime.now(timezone.utc),
+            'status': ToolExecutionStatus.SUCCESS,
+        },
+        llm_context='The current time is 10:00.',
+    )
 
     payload = CreateMessageRequest(content='Trigger tool call')
     emitted_events = []
@@ -859,10 +888,25 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
     ):
         emitted_events.append(event)
 
-    assert len(emitted_events) == 1
-    assert emitted_events[0].startswith('event: error')
-    error_payload = json.loads(emitted_events[0].split('data: ', 1)[1].strip())
-    assert 'not yet supported' in error_payload['detail'].lower()
+    assert any(event.startswith('event: token') for event in emitted_events)
+    tool_events = [
+        json.loads(event.split('data: ', 1)[1].strip())
+        for event in emitted_events
+        if event.startswith('event: tool_call')
+    ]
+    assert [tool_event['status'] for tool_event in tool_events] == [
+        'requested',
+        'running',
+        'completed',
+    ]
+    done_event = next(
+        event for event in emitted_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['content'] == 'Checking the current time.'
+    assert done_payload['annotations']['tools'] == [
+        {'id': None, 'name': 'current_time', 'status': 'completed'}
+    ]
 
     result = await async_session.execute(
         select(Message)
@@ -870,8 +914,12 @@ async def test_add_message_to_conversation_stream_errors_on_tool_calls(
         .order_by(Message.sequence_number.asc())
     )
     persisted_messages = list(result.scalars().all())
-    assert len(persisted_messages) == 1
-    assert persisted_messages[0].role == 'user'
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Checking the current time.'
+    assert persisted_messages[1].annotations['tools'] == [
+        {'id': None, 'name': 'current_time', 'status': 'completed'}
+    ]
 
 
 async def test_add_message_to_conversation_stream_persists_partial_on_cancellation(

--- a/apps/assistant-backend/tests/services/test_conversation_service.py
+++ b/apps/assistant-backend/tests/services/test_conversation_service.py
@@ -815,7 +815,7 @@ async def test_add_message_to_conversation_stream_skips_assistant_persistence_wi
     assert persisted_messages[0].role == 'user'
 
 
-async def test_add_message_to_conversation_stream_errors_on_tool_calls(
+async def test_add_message_to_conversation_stream_executes_tool_calls(
     conversation_service,
     mock_llm_service,
     mock_context_assembly,

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -184,6 +184,80 @@ describe("ConversationsChat", () => {
       });
     });
 
+    it("renders streaming tool lifecycle updates inline", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValueOnce({ items: [] });
+      let releaseStream!: () => void;
+      const streamPaused = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+
+      async function* streamEvents() {
+        yield {
+          event: "tool_call" as const,
+          data: {
+            id: "call-1",
+            name: "web_search",
+            status: "requested" as const,
+          },
+        };
+        yield {
+          event: "tool_call" as const,
+          data: {
+            id: "call-1",
+            name: "web_search",
+            status: "running" as const,
+          },
+        };
+        await streamPaused;
+        yield { event: "token" as const, data: "Done" };
+        yield {
+          event: "done" as const,
+          data: {
+            conversation_id: "new-conv",
+            message_id: "assistant-1",
+            content: "Done",
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [{ name: "web_search", status: "completed" as const }],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+            },
+          },
+        };
+      }
+
+      mockStreamConversation.mockReturnValueOnce(streamEvents());
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      );
+      await user.type(input, "Search");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Using web_search")).toBeInTheDocument();
+      });
+
+      releaseStream();
+
+      await waitFor(() => {
+        expect(screen.getByText("Done")).toBeInTheDocument();
+      });
+    });
+
     it("shows welcome message when no conversation is selected", async () => {
       mockListConversations.mockResolvedValueOnce({ items: [] });
 

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -202,12 +202,24 @@ function SourceDetail({ title, url, snippet, rationale }: SourceDetailProps) {
 // ToolDetail: Renders tool usage information
 interface ToolDetailProps {
   name: string;
-  status: "completed" | "failed";
+  status: "requested" | "running" | "completed" | "failed";
 }
 
 function ToolDetail({ name, status }: ToolDetailProps) {
-  const statusColor = status === "completed" ? "#2f6b53" : "#a54034";
-  const statusLabel = status === "completed" ? "Completed" : "Failed";
+  const statusColor =
+    status === "completed"
+      ? "#2f6b53"
+      : status === "failed"
+        ? "#a54034"
+        : "#315c85";
+  const statusLabel =
+    status === "completed"
+      ? "Completed"
+      : status === "failed"
+        ? "Failed"
+        : status === "running"
+          ? "Running"
+          : "Requested";
 
   return (
     <div className="evidence-tool-item">
@@ -222,6 +234,33 @@ function ToolDetail({ name, status }: ToolDetailProps) {
         </span>
       </div>
       <p className="type-meta text-[#6e675d] mt-1">{statusLabel}</p>
+    </div>
+  );
+}
+
+function StreamingToolStatusRow({
+  tools,
+}: {
+  tools: AssistantAnnotations["tools"];
+}) {
+  if (tools.length === 0) return null;
+
+  const statusCopy = (tool: AssistantAnnotations["tools"][number]) => {
+    if (tool.status === "failed") return `${tool.name} failed`;
+    if (tool.status === "completed") return `Used ${tool.name}`;
+    return `Using ${tool.name}`;
+  };
+
+  return (
+    <div className="streaming-tool-status-row" aria-live="polite">
+      {tools.map((tool) => (
+        <div
+          key={tool.id || `${tool.name}-${tool.status}`}
+          className={`streaming-tool-status streaming-tool-status-${tool.status}`}
+        >
+          {statusCopy(tool)}
+        </div>
+      ))}
     </div>
   );
 }
@@ -940,6 +979,13 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
                                     </div>
                                   </div>
                                 )}
+                                {msg.annotations &&
+                                  msg.annotations.tools.length > 0 &&
+                                  msg.id.startsWith("streaming-") && (
+                                    <StreamingToolStatusRow
+                                      tools={msg.annotations.tools}
+                                    />
+                                  )}
                                 <MarkdownContent content={msg.content} />
                               </>
                             ) : (

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -253,9 +253,9 @@ function StreamingToolStatusRow({
 
   return (
     <div className="streaming-tool-status-row" aria-live="polite">
-      {tools.map((tool) => (
+      {tools.map((tool, idx) => (
         <div
-          key={tool.id || `${tool.name}-${tool.status}`}
+          key={tool.id || tool.name + "-" + idx}
           className={`streaming-tool-status streaming-tool-status-${tool.status}`}
         >
           {statusCopy(tool)}

--- a/apps/assistant-ui/src/hooks/useStreamingConversation.test.ts
+++ b/apps/assistant-ui/src/hooks/useStreamingConversation.test.ts
@@ -146,6 +146,69 @@ describe("useStreamingConversation hook", () => {
     );
   });
 
+  it("updates tool lifecycle status as the stream progresses", async () => {
+    const mockEvents: SSEEvent[] = [
+      {
+        event: "tool_call" as const,
+        data: {
+          id: "call-1",
+          name: "web_search",
+          status: "requested" as const,
+        },
+      },
+      {
+        event: "tool_call" as const,
+        data: {
+          id: "call-1",
+          name: "web_search",
+          status: "running" as const,
+        },
+      },
+      {
+        event: "tool_call" as const,
+        data: {
+          id: "call-1",
+          name: "web_search",
+          status: "completed" as const,
+        },
+      },
+      {
+        event: "done" as const,
+        data: {
+          conversation_id: "conv-1",
+          message_id: "msg-123",
+          content: "Done",
+          annotations: {
+            thought: null,
+            sources: [],
+            tools: [{ name: "web_search", status: "completed" as const }],
+            memory_hits: [],
+            memory_saved: [],
+            failure: null,
+          },
+        } as StreamDoneData,
+      },
+    ];
+
+    async function* mockGenerator(): AsyncGenerator<SSEEvent, void, unknown> {
+      for (const event of mockEvents) {
+        yield event;
+      }
+    }
+
+    vi.mocked(api.streamConversation).mockReturnValue(mockGenerator());
+
+    const { result } = renderHook(() => useStreamingConversation());
+
+    await act(async () => {
+      await result.current.stream("conv-1", "Hi");
+    });
+
+    expect(result.current.currentMessage?.annotations?.tools).toEqual([
+      { name: "web_search", status: "completed" },
+    ]);
+  });
+
   it("throws error on unexpected end-of-stream (no 'done' event)", async () => {
     async function* mockGenerator(): AsyncGenerator<SSEEvent, void, unknown> {
       yield { event: "token" as const, data: "Partial content" };

--- a/apps/assistant-ui/src/index.css
+++ b/apps/assistant-ui/src/index.css
@@ -214,6 +214,30 @@
     color: var(--color-text-muted);
   }
 
+  .streaming-tool-status-row {
+    @apply mb-2 flex flex-wrap gap-2;
+  }
+
+  .streaming-tool-status {
+    @apply inline-flex items-center rounded-full border px-3 py-1;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .streaming-tool-status-requested,
+  .streaming-tool-status-running {
+    @apply border-[#c9bfae] bg-[#f6f2ea] text-[#315c85];
+  }
+
+  .streaming-tool-status-completed {
+    @apply border-[#c9bfae] bg-[#f6f2ea] text-[#2f6b53];
+  }
+
+  .streaming-tool-status-failed {
+    @apply border-[#e0b5ad] bg-[#f8e9e6] text-[#a54034];
+  }
+
   /* Trust metadata row */
   .trust-row {
     @apply flex flex-wrap gap-3 mt-2 pt-2 border-t border-[#ded6c7];

--- a/apps/assistant-ui/src/types/api.ts
+++ b/apps/assistant-ui/src/types/api.ts
@@ -47,7 +47,7 @@ export interface SourceAnnotation {
 }
 
 export interface ToolAnnotation {
-  id?: string;
+  id?: string | null;
   name: string;
   status: "requested" | "running" | "completed" | "failed";
 }

--- a/apps/assistant-ui/src/types/api.ts
+++ b/apps/assistant-ui/src/types/api.ts
@@ -49,7 +49,7 @@ export interface SourceAnnotation {
 export interface ToolAnnotation {
   id?: string;
   name: string;
-  status: "completed" | "failed";
+  status: "requested" | "running" | "completed" | "failed";
 }
 
 export interface MemoryHitAnnotation {


### PR DESCRIPTION
## Summary
- execute tool calls during streamed assistant turns instead of failing the stream
- emit tool lifecycle SSE events and persist tool metadata into final assistant annotations
- surface transient tool status in the chat UI and update streaming tests to cover the new behavior

## Validation
- Backend local checks were run in this environment, but full local validation had environment-specific blockers earlier in the session
- Proceeding with PR creation per user instruction that the remaining validation issue was environment-specific