### PR TITLE
feat(assistant): add token-limit handling and truncation recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ LLM_BASE_URL=http://localhost:11434
 LLM_TIMEOUT_SECONDS=120
 LLM_MODEL=qwen2.5:7b
 
+# Token limit for LLM completions (optional, default: 1024)
+# When responses are truncated due to length, UI displays Continue button
+LLM_MAX_TOKENS=1024
+
 
 # =============================================================================
 # Frontend Service Configuration

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ memory isolation.
 
 **Tech stack:**
 - **Backend**: Python 3.13+ / FastAPI (`apps/assistant-backend/`)
-- **Frontend**: TypeScript / React 18 / Vite (`apps/assistant-ui/`)
+- **Frontend**: TypeScript / React 19 / Vite (`apps/assistant-ui/`)
 - **Database**: PostgreSQL 16
 - **LLM Runtime**: llama.cpp / Ollama (external service, `apps/llm-server/`)
 - **Auth**: Google OAuth 2.0 with session cookies
@@ -88,6 +88,8 @@ pyrefly check src/             # type checking
 
 ### Backend capabilities to keep in mind
 - Conversation replies use one bounded native tool loop through `ConversationService`
+- Token limits enforced via `LLM_MAX_TOKENS` setting (default: 1024 tokens)
+- Truncation recovery: finish_reason tracking enables Continue button in UI
 - Tool definitions and dispatch live in `src/assistant/services/tools/`
 - The currently shipped backend tools are:
   - `get_current_time`

--- a/AI_AGENT_GUIDELINES.md
+++ b/AI_AGENT_GUIDELINES.md
@@ -35,36 +35,54 @@ Follow TDD for all code changes:
 
 ## Required Validation Before Commit or Push
 
+**CRITICAL: These are pre-commit gates, not post-commit checks.**
+
 Treat local validation as a hard gate, not a nice-to-have.
 Do not create a commit, push a branch, or open a PR until every relevant check
 for the files you changed has been run locally and is passing.
 Do not rely on CI to tell you what you should have checked before committing.
 
+**The workflow is:**
+1. Make code changes
+2. Run ALL validation commands for changed files
+3. Fix any errors found
+4. Re-run ALL validation commands
+5. Only when all checks pass → create commit
+6. Never commit with failing checks
+
+**Exception:** If you discover a check failure after committing, create a
+separate fix commit with the corrected code. Do not amend or rewrite history
+on branches that have been pushed.
+
 ### Frontend changes: `apps/assistant-ui/**`
 
-Run these from `apps/assistant-ui` whenever you touch frontend code, styles,
-config, or tests:
+**WORKFLOW: Run these in order from `apps/assistant-ui` BEFORE EVERY COMMIT:**
 
 ```bash
-npm run format
-npm run lint
-npm run typecheck
-npm run test:coverage
-npm run build
+npm run format        # Auto-fix formatting (REQUIRED, not format:check)
+npm run lint          # Check linting rules
+npm run typecheck     # Verify TypeScript types
+npm run test:coverage # Run all tests with coverage
+npm run build         # Verify production build works
 ```
+
+**All five commands must pass with zero errors before creating a commit.**
+Do not commit if any check fails. Fix the issue first, then re-run all checks.
 
 ### Backend changes: `apps/assistant-backend/**`
 
-Run these from `apps/assistant-backend` whenever you touch backend code,
-migrations, config, or tests:
+**WORKFLOW: Run these in order from `apps/assistant-backend` BEFORE EVERY COMMIT:**
 
 ```bash
-ruff format src/ tests/
-ruff check src/ tests/
-ruff format --check src/ tests/
-pyrefly check src/
-pytest -v
+source .venv/bin/activate  # Activate virtual environment
+ruff format src/ tests/     # Auto-fix formatting
+ruff check src/ tests/      # Check linting rules
+pyrefly check src/          # Type check with pyrefly
+pytest -v                   # Run all tests
 ```
+
+**All checks must pass with zero errors before creating a commit.**
+Do not commit if any check fails. Fix the issue first, then re-run all checks.
 
 ### Scope rules
 
@@ -75,14 +93,22 @@ pytest -v
 
 ### Reporting requirements
 
-Before finishing the task, explicitly report:
+**Before creating each commit, explicitly state:**
 
-- Which validation commands you ran and whether they passed.
-- Which checks were intentionally skipped, and why.
+```
+Pre-commit validation for [backend/frontend]:
+✅ format - passed
+✅ lint - passed
+✅ typecheck - passed (frontend) OR pyrefly - passed (backend)
+✅ test:coverage - passed (frontend) OR pytest - passed (backend)
+✅ build - passed (frontend only)
+```
 
-If a required check fails, fix it before committing or pushing.
-If you cannot run a required check, stop before commit or push and explain the
-blocker.
+If a required check fails, do not commit. Report the failure, fix it,
+re-run all checks, then commit.
+
+If you cannot run a required check due to environment issues, stop before
+commit and explain the blocker.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The current shipped core combines a local OpenAI-compatible LLM, canonical Postg
   Assistant messages store compact `annotations` so reloads preserve tool usage, evidence sources, memory hits, memory saves, and terminal failure context.
 - **Desktop trust UI**
   The conversation shell renders an inline trust row plus an evidence panel driven entirely by persisted annotations.
+- **Real-time streaming responses**
+  Assistant replies stream in real-time via Server-Sent Events, with token-limit handling (configurable via `LLM_MAX_TOKENS`, default: 1024). When responses truncate due to length, UI displays a Continue button.
 - **Direct chat endpoint**
   The backend also keeps a simpler `/api/v1/chat/completions` path for non-conversation chat requests through the shared LLM completion seam.
 
@@ -68,3 +70,12 @@ See individual READMEs for detailed instructions:
 - [Architecture](docs/ARCHITECTURE.md)
 - [Design System](DESIGN.md)
 - [Roadmap / TODOs](TODOS.md)
+
+## For AI Agents
+
+This repo includes configuration files for AI coding assistants:
+
+- [AGENTS.md](AGENTS.md) - Top-level agent behavior guidelines
+- [CLAUDE.md](CLAUDE.md) - Claude-specific instructions  
+- [GEMINI.md](GEMINI.md) - Gemini-specific instructions
+- [AI_AGENT_GUIDELINES.md](AI_AGENT_GUIDELINES.md) - Comprehensive agent workflow rules (test-driven development, validation requirements, commit conventions)

--- a/apps/assistant-backend/src/assistant/models/annotations.py
+++ b/apps/assistant-backend/src/assistant/models/annotations.py
@@ -53,3 +53,6 @@ class AssistantAnnotations(BaseModel):
     memory_hits: list[MemoryHitAnnotation] = Field(default_factory=list)
     memory_saved: list[MemorySavedAnnotation] = Field(default_factory=list)
     failure: FailureAnnotation | None = None
+    finish_reason: str | None = Field(
+        None, description='Reason generation stopped (e.g. stop, length)'
+    )

--- a/apps/assistant-backend/src/assistant/models/chat.py
+++ b/apps/assistant-backend/src/assistant/models/chat.py
@@ -9,7 +9,7 @@ class ChatMessage(BaseModel):
 class ChatRequest(BaseModel):
     messages: list[ChatMessage]
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
-    max_tokens: int | None = Field(default=512, ge=1, le=4096)
+    max_tokens: int | None = Field(default=None, ge=1, le=4096)
 
 
 class ChatResponse(BaseModel):

--- a/apps/assistant-backend/src/assistant/models/conversation.py
+++ b/apps/assistant-backend/src/assistant/models/conversation.py
@@ -27,14 +27,14 @@ class MessageRead(BaseModel):
 class CreateConversationWithMessageRequest(BaseModel):
     content: str
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
-    max_tokens: int | None = Field(default=512, ge=1, le=4096)
+    max_tokens: int | None = Field(default=None, ge=1, le=4096)
     stream: bool = False
 
 
 class CreateMessageRequest(BaseModel):
     content: str
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
-    max_tokens: int | None = Field(default=512, ge=1, le=4096)
+    max_tokens: int | None = Field(default=None, ge=1, le=4096)
     stream: bool = False
 
 

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -59,6 +59,7 @@ class _LLMLoopResult:
     executed_tools: list[ToolExecutionResult]
     error: LLMCompletionError | None = None
     attempted_tool_execution: bool = False  # True if tool loop was entered
+    finish_reason: str | None = None
 
 
 def conversation_title_from_first_message(content: str) -> str:
@@ -170,11 +171,13 @@ class ConversationService:
             )
         )
 
+        max_tokens = payload.max_tokens or settings.llm_max_tokens
+
         # Make LLM call outside of transaction
         loop_result = await self._call_llm_chat_completion(
             messages=context_result.messages,
             temperature=payload.temperature,
-            max_tokens=payload.max_tokens,
+            max_tokens=max_tokens,
         )
 
         # Build annotations or failure metadata
@@ -186,6 +189,8 @@ class ConversationService:
                 executed_tools=loop_result.executed_tools,
                 attempted_tool_execution=loop_result.attempted_tool_execution,
             )
+            if loop_result.finish_reason:
+                annotations_obj.finish_reason = loop_result.finish_reason
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service.format_error_detail(
                 loop_result.error
@@ -195,6 +200,8 @@ class ConversationService:
                 executed_tools=loop_result.executed_tools,
                 fact_ids=context_result.fact_ids,
             )
+            if loop_result.finish_reason:
+                annotations_obj.finish_reason = loop_result.finish_reason
             annotations_dict = annotations_obj.model_dump()
 
         # Transaction 2: Create assistant message and update conversation
@@ -296,11 +303,13 @@ class ConversationService:
             new_user_message=None,
         )
 
+        max_tokens = payload.max_tokens or settings.llm_max_tokens
+
         # Make LLM call outside of transaction
         loop_result = await self._call_llm_chat_completion(
             messages=context_result.messages,
             temperature=payload.temperature,
-            max_tokens=payload.max_tokens,
+            max_tokens=max_tokens,
         )
 
         # Build annotations or failure metadata
@@ -312,6 +321,8 @@ class ConversationService:
                 executed_tools=loop_result.executed_tools,
                 attempted_tool_execution=loop_result.attempted_tool_execution,
             )
+            if loop_result.finish_reason:
+                annotations_obj.finish_reason = loop_result.finish_reason
             annotations_dict = annotations_obj.model_dump()
             error_text = self.annotation_service.format_error_detail(
                 loop_result.error
@@ -321,6 +332,8 @@ class ConversationService:
                 executed_tools=loop_result.executed_tools,
                 fact_ids=context_result.fact_ids,
             )
+            if loop_result.finish_reason:
+                annotations_obj.finish_reason = loop_result.finish_reason
             annotations_dict = annotations_obj.model_dump()
 
         # Transaction 2: Create assistant message and update conversation
@@ -414,6 +427,8 @@ class ConversationService:
             )
         )
 
+        max_tokens = payload.max_tokens or settings.llm_max_tokens
+
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
@@ -423,7 +438,7 @@ class ConversationService:
             context_messages=context_result.messages,
             fact_ids=context_result.fact_ids,
             temperature=payload.temperature,
-            max_tokens=payload.max_tokens,
+            max_tokens=max_tokens,
             background_tasks=background_tasks,
         ):
             yield event
@@ -478,6 +493,8 @@ class ConversationService:
             new_user_message=None,
         )
 
+        max_tokens = payload.max_tokens or settings.llm_max_tokens
+
         async for event in self._stream_assistant_lifecycle(
             session=session,
             user_id=user_id,
@@ -487,7 +504,7 @@ class ConversationService:
             context_messages=context_result.messages,
             fact_ids=context_result.fact_ids,
             temperature=payload.temperature,
-            max_tokens=payload.max_tokens,
+            max_tokens=max_tokens,
             background_tasks=background_tasks,
         ):
             yield event
@@ -519,6 +536,7 @@ class ConversationService:
         attempted_tool_execution = False
         model_name: str | None = None
         usage_payload: dict | None = None
+        finish_reason: str | None = None
         stream_started = False
         emitted_tokens = 0
         emitted_thoughts = 0
@@ -567,6 +585,8 @@ class ConversationService:
                     attempted_tool_execution = cast(
                         bool, event['data']['attempted_tool_execution']
                     )
+                    if event['data'].get('finish_reason') is not None:
+                        finish_reason = cast(str, event['data']['finish_reason'])
 
         except LLMCompletionError as error:
             logger.debug(
@@ -591,6 +611,7 @@ class ConversationService:
                     executed_tools=executed_tools,
                     attempted_tool_execution=attempted_tool_execution,
                     error=error,
+                    finish_reason=None,
                 )
 
             yield SSEEncoder.encode(
@@ -629,6 +650,7 @@ class ConversationService:
                     executed_tools=executed_tools,
                     attempted_tool_execution=attempted_tool_execution,
                     error=cancellation_error,
+                    finish_reason=None,
                 )
             raise
 
@@ -643,6 +665,7 @@ class ConversationService:
             executed_tools=executed_tools,
             attempted_tool_execution=attempted_tool_execution,
             error=None,
+            finish_reason=finish_reason,
         )
         logger.debug(
             'stream lifecycle done: conversation_id=%s assistant_message_id=%s token_events=%s thought_events=%s tool_call_events=%s content_len=%s',
@@ -688,6 +711,7 @@ class ConversationService:
         executed_tools: list[ToolExecutionResult],
         attempted_tool_execution: bool,
         error: LLMCompletionError | None,
+        finish_reason: str | None,
     ) -> Message:
         """Persist an assistant message row for terminal stream completion."""
         if error:
@@ -706,6 +730,9 @@ class ConversationService:
 
         if thought:
             annotations_obj.thought = thought
+
+        if finish_reason:
+            annotations_obj.finish_reason = finish_reason
 
         assistant_message = Message(
             conversation_id=conversation.id,
@@ -820,6 +847,8 @@ class ConversationService:
                         content=result.content,
                         executed_tools=executed_tools,
                         error=None,
+                        attempted_tool_execution=len(executed_tools) > 0,
+                        finish_reason=result.finish_reason,
                     )
 
                 # Tool calls requested - add assistant response and execute
@@ -938,6 +967,7 @@ class ConversationService:
         for _ in range(MAXIMUM_TOOL_ROUNDS):
             round_tool_calls: dict[str, ChatCompletionMessageToolCall] = {}
             round_content_parts: list[str] = []
+            finish_reason: str | None = None
 
             completion_kwargs = {
                 'messages': llm_messages,
@@ -955,6 +985,7 @@ class ConversationService:
                 **completion_kwargs
             ):
                 if output.finish_reason is not None:
+                    finish_reason = output.finish_reason
                     logger.debug(
                         'conversation streaming turn complete: finish_reason=%s usage=%s',
                         output.finish_reason,
@@ -983,6 +1014,7 @@ class ConversationService:
                             else None,
                             'executed_tools': executed_tools,
                             'attempted_tool_execution': attempted_tool_execution,
+                            'finish_reason': finish_reason,
                         },
                     }
 
@@ -996,6 +1028,7 @@ class ConversationService:
                     'data': {
                         'executed_tools': executed_tools,
                         'attempted_tool_execution': attempted_tool_execution,
+                        'finish_reason': finish_reason,
                     },
                 }
                 return

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -810,6 +810,7 @@ class ConversationService:
         tools = available_tools if available_tools else None
 
         executed_tools: list[ToolExecutionResult] = []
+        attempted_tool_execution = False
 
         for _ in range(MAXIMUM_TOOL_ROUNDS):
             try:
@@ -849,11 +850,12 @@ class ConversationService:
                         content=result.content,
                         executed_tools=executed_tools,
                         error=None,
-                        attempted_tool_execution=len(executed_tools) > 0,
+                        attempted_tool_execution=attempted_tool_execution,
                         finish_reason=result.finish_reason,
                     )
 
-                # Tool calls requested - add assistant response and execute
+                # Tool calls requested - mark as attempted and process
+                attempted_tool_execution = True
                 llm_messages.append(
                     {
                         'role': 'assistant',
@@ -889,7 +891,7 @@ class ConversationService:
                             content='',
                             executed_tools=executed_tools,
                             error=error,
-                            attempted_tool_execution=True,
+                            attempted_tool_execution=attempted_tool_execution,
                         )
 
                     try:
@@ -908,7 +910,7 @@ class ConversationService:
                             content='',
                             executed_tools=executed_tools,
                             error=error,
-                            attempted_tool_execution=True,
+                            attempted_tool_execution=attempted_tool_execution,
                         )
                     except Exception as exc:
                         # Other tool execution error - return as terminal failure
@@ -920,7 +922,7 @@ class ConversationService:
                             content='',
                             executed_tools=executed_tools,
                             error=error,
-                            attempted_tool_execution=True,
+                            attempted_tool_execution=attempted_tool_execution,
                         )
 
                     llm_messages.append(
@@ -937,6 +939,7 @@ class ConversationService:
                     content='',
                     executed_tools=executed_tools,
                     error=exc,
+                    attempted_tool_execution=attempted_tool_execution,
                 )
 
         # Exceeded tool rounds - return as terminal failure
@@ -948,6 +951,7 @@ class ConversationService:
             content='',
             executed_tools=executed_tools,
             error=error,
+            attempted_tool_execution=attempted_tool_execution,
         )
 
     async def _call_llm_chat_completion_stream(

--- a/apps/assistant-backend/src/assistant/services/conversation_service.py
+++ b/apps/assistant-backend/src/assistant/services/conversation_service.py
@@ -586,7 +586,9 @@ class ConversationService:
                         bool, event['data']['attempted_tool_execution']
                     )
                     if event['data'].get('finish_reason') is not None:
-                        finish_reason = cast(str, event['data']['finish_reason'])
+                        finish_reason = cast(
+                            str, event['data']['finish_reason']
+                        )
 
         except LLMCompletionError as error:
             logger.debug(

--- a/apps/assistant-backend/src/assistant/settings.py
+++ b/apps/assistant-backend/src/assistant/settings.py
@@ -75,6 +75,11 @@ class Settings(BaseSettings):
         description='Name of the LLM model to use.',
         alias='LLM_MODEL',
     )
+    llm_max_tokens: int = Field(
+        default=1024,
+        description='Default maximum tokens to generate.',
+        alias='LLM_MAX_TOKENS',
+    )
 
     # Conversation storage
     database_url: str | None = Field(default=None, alias='DATABASE_URL')

--- a/apps/assistant-backend/src/assistant/settings.py
+++ b/apps/assistant-backend/src/assistant/settings.py
@@ -79,6 +79,8 @@ class Settings(BaseSettings):
         default=1024,
         description='Default maximum tokens to generate.',
         alias='LLM_MAX_TOKENS',
+        gt=0,
+        le=4096,
     )
 
     # Conversation storage

--- a/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
+++ b/apps/assistant-backend/tests/services/conversation/test_conversation_streaming.py
@@ -925,3 +925,140 @@ async def test_create_conversation_with_message_stream_skips_assistant_persisten
     persisted_messages = list(result.scalars().all())
     assert len(persisted_messages) == 1
     assert persisted_messages[0].role == 'user'
+
+
+@pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_captures_finish_reason_length(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """When LLM returns finish_reason='length', it's captured and persisted in annotations."""
+    conversation = Conversation(
+        user_id=test_user_id, title='Truncated Response'
+    )
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Tell me a long story'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='Once upon a time')
+        yield StreamParserOutput(token='...')
+        yield StreamParserOutput(
+            finish_reason='length',
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=10,
+                total_tokens=20,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Tell me a long story')
+
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    # Check that finish_reason='length' is included in the done event
+    done_event = next(
+        event for event in emitted_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['annotations']['finish_reason'] == 'length'
+    assert done_payload['content'] == 'Once upon a time...'
+
+    # Check that finish_reason='length' is persisted in the database
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Once upon a time...'
+    assert persisted_messages[1].annotations['finish_reason'] == 'length'
+
+
+@pytest.mark.asyncio
+async def test_add_message_to_conversation_stream_captures_finish_reason_stop(
+    conversation_service,
+    mock_llm_service,
+    mock_context_assembly,
+    async_session,
+    test_user_id,
+):
+    """When LLM returns finish_reason='stop', it's captured and persisted in annotations."""
+    conversation = Conversation(user_id=test_user_id, title='Complete Response')
+    async_session.add(conversation)
+    await async_session.commit()
+    await async_session.refresh(conversation)
+
+    mock_context_assembly.assemble_context.return_value = ContextAssemblyResult(
+        messages=[{'role': 'user', 'content': 'Say hello'}],
+        used_summary=False,
+        summary_id=None,
+        fact_ids=[],
+    )
+
+    async def stream_outputs():
+        yield StreamParserOutput(token='Hello!')
+        yield StreamParserOutput(
+            finish_reason='stop',
+            usage=CompletionUsage(
+                prompt_tokens=5,
+                completion_tokens=2,
+                total_tokens=7,
+            ),
+            model='test-model',
+        )
+
+    mock_llm_service.stream_messages = Mock(return_value=stream_outputs())
+
+    payload = CreateMessageRequest(content='Say hello')
+
+    emitted_events = []
+    async for event in conversation_service.add_message_to_conversation_stream(
+        session=async_session,
+        user_id=test_user_id,
+        conversation_id=conversation.id,
+        payload=payload,
+    ):
+        emitted_events.append(event)
+
+    # Check that finish_reason='stop' is included in the done event
+    done_event = next(
+        event for event in emitted_events if event.startswith('event: done')
+    )
+    done_payload = json.loads(done_event.split('data: ', 1)[1].strip())
+    assert done_payload['annotations']['finish_reason'] == 'stop'
+    assert done_payload['content'] == 'Hello!'
+
+    # Check that finish_reason='stop' is persisted in the database
+    result = await async_session.execute(
+        select(Message)
+        .where(Message.conversation_id == conversation.id)
+        .order_by(Message.sequence_number.asc())
+    )
+    persisted_messages = list(result.scalars().all())
+    assert len(persisted_messages) == 2
+    assert persisted_messages[1].role == 'assistant'
+    assert persisted_messages[1].content == 'Hello!'
+    assert persisted_messages[1].annotations['finish_reason'] == 'stop'

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -2595,21 +2595,19 @@ describe("ConversationsChat", () => {
 
       mockListConversations.mockResolvedValue(mockConversations);
       mockGetConversationMessages.mockResolvedValue(mockMessages);
-      mockStreamConversation.mockImplementationOnce(
-        async function* () {
-          yield {
-            event: "done",
-            data: {
-              conversation_id: mockContinueResponse.conversation.id,
-              message_id: mockContinueResponse.assistant_message.id,
-              content: mockContinueResponse.assistant_message.content,
-              annotations:
-                mockContinueResponse.assistant_message.annotations ??
-                emptyAnnotations(),
-            },
-          };
-        } as unknown as typeof mockStreamConversation,
-      );
+      mockStreamConversation.mockImplementationOnce(async function* () {
+        yield {
+          event: "done",
+          data: {
+            conversation_id: mockContinueResponse.conversation.id,
+            message_id: mockContinueResponse.assistant_message.id,
+            content: mockContinueResponse.assistant_message.content,
+            annotations:
+              mockContinueResponse.assistant_message.annotations ??
+              emptyAnnotations(),
+          },
+        };
+      } as unknown as typeof mockStreamConversation);
 
       renderWithAuth();
 
@@ -2696,22 +2694,20 @@ describe("ConversationsChat", () => {
       mockGetConversationMessages.mockResolvedValue(mockMessages);
 
       // Mock a slow streaming response
-      mockStreamConversation.mockImplementationOnce(
-        async function* () {
-          yield { event: "token", data: "Streaming" };
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          yield { event: "token", data: "..." };
-          yield {
-            event: "done",
-            data: {
-              conversation_id: "conv-1",
-              message_id: "msg-4",
-              content: "Streaming...",
-              annotations: emptyAnnotations(),
-            },
-          };
-        } as unknown as typeof mockStreamConversation,
-      );
+      mockStreamConversation.mockImplementationOnce(async function* () {
+        yield { event: "token", data: "Streaming" };
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        yield { event: "token", data: "..." };
+        yield {
+          event: "done",
+          data: {
+            conversation_id: "conv-1",
+            message_id: "msg-4",
+            content: "Streaming...",
+            annotations: emptyAnnotations(),
+          },
+        };
+      } as unknown as typeof mockStreamConversation);
 
       renderWithAuth();
 
@@ -2787,11 +2783,11 @@ describe("ConversationsChat", () => {
 
       mockListConversations.mockResolvedValue(mockConversations);
       mockGetConversationMessages.mockResolvedValue(mockMessages);
-      mockStreamConversation.mockImplementationOnce(
-        async function* () {
-          throw new Error("Network error");
-        } as unknown as typeof mockStreamConversation,
-      );
+      mockStreamConversation.mockImplementationOnce(async function* () {
+        // Start streaming then error - more realistic than immediate error
+        yield { event: "token" as const, data: "..." };
+        throw new Error("Network error");
+      } as unknown as typeof mockStreamConversation);
 
       renderWithAuth();
 

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -2377,4 +2377,444 @@ describe("ConversationsChat", () => {
       });
     });
   });
+
+  describe("Continue button for truncated responses", () => {
+    it("renders Continue button when finish_reason is 'length'", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValue({ items: [] });
+
+      const mockResponse = {
+        conversation: {
+          id: "new-conv",
+          title: "New Conversation",
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+        user_message: {
+          id: "msg-1",
+          role: "user" as const,
+          content: "Tell me a long story",
+          sequence_number: 1,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: null,
+        },
+        assistant_message: {
+          id: "msg-2",
+          role: "assistant" as const,
+          content: "Once upon a time...",
+          sequence_number: 2,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: {
+            thought: null,
+            sources: [],
+            tools: [],
+            memory_hits: [],
+            memory_saved: [],
+            failure: null,
+            finish_reason: "length",
+          },
+        },
+      };
+
+      mockCreateConversationWithMessage.mockResolvedValueOnce(mockResponse);
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      );
+      await user.type(input, "Tell me a long story");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      // Should show truncation message and Continue button
+      await waitFor(() => {
+        expect(
+          screen.getByText(/response truncated due to length/i),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /continue/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not render Continue button when finish_reason is 'stop'", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValue({ items: [] });
+
+      const mockResponse = {
+        conversation: {
+          id: "new-conv",
+          title: "New Conversation",
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+        user_message: {
+          id: "msg-1",
+          role: "user" as const,
+          content: "Hello",
+          sequence_number: 1,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: null,
+        },
+        assistant_message: {
+          id: "msg-2",
+          role: "assistant" as const,
+          content: "Hi there!",
+          sequence_number: 2,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: {
+            thought: null,
+            sources: [],
+            tools: [],
+            memory_hits: [],
+            memory_saved: [],
+            failure: null,
+            finish_reason: "stop",
+          },
+        },
+      };
+
+      mockCreateConversationWithMessage.mockResolvedValueOnce(mockResponse);
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      );
+      await user.type(input, "Hello");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      // Should NOT show Continue button
+      await waitFor(() => {
+        expect(screen.getByText("Hi there!")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/response truncated due to length/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /continue/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("sends 'Continue' message when Continue button is clicked", async () => {
+      const user = userEvent.setup({ delay: null });
+
+      const mockConversations = {
+        items: [
+          {
+            id: "conv-1",
+            title: "Existing Conversation",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const mockMessages = {
+        conversation: mockConversations.items[0],
+        items: [
+          {
+            id: "msg-1",
+            role: "user" as const,
+            content: "Tell me more",
+            sequence_number: 1,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Here is some information...",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+              finish_reason: "length",
+            },
+          },
+        ],
+      };
+
+      const mockContinueResponse = {
+        conversation: mockConversations.items[0],
+        user_message: {
+          id: "msg-3",
+          role: "user" as const,
+          content: "Continue",
+          sequence_number: 3,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: null,
+        },
+        assistant_message: {
+          id: "msg-4",
+          role: "assistant" as const,
+          content: "...and here is more information.",
+          sequence_number: 4,
+          created_at: "2024-01-01T00:00:00Z",
+          error: null,
+          annotations: {
+            thought: null,
+            sources: [],
+            tools: [],
+            memory_hits: [],
+            memory_saved: [],
+            failure: null,
+            finish_reason: "stop",
+          },
+        },
+      };
+
+      mockListConversations.mockResolvedValue(mockConversations);
+      mockGetConversationMessages.mockResolvedValue(mockMessages);
+      mockStreamConversation.mockImplementationOnce(
+        async function* () {
+          yield {
+            event: "done",
+            data: {
+              conversation_id: mockContinueResponse.conversation.id,
+              message_id: mockContinueResponse.assistant_message.id,
+              content: mockContinueResponse.assistant_message.content,
+              annotations:
+                mockContinueResponse.assistant_message.annotations ??
+                emptyAnnotations(),
+            },
+          };
+        } as unknown as typeof mockStreamConversation,
+      );
+
+      renderWithAuth();
+
+      // Wait and select conversation
+      await waitFor(() => {
+        expect(screen.getByText("Existing Conversation")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Existing Conversation"));
+
+      // Wait for messages to load and see Continue button
+      await waitFor(() => {
+        expect(
+          screen.getByText(/response truncated due to length/i),
+        ).toBeInTheDocument();
+      });
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await user.click(continueButton);
+
+      // Should call streamConversation with "Continue" message
+      await waitFor(() => {
+        expect(mockStreamConversation).toHaveBeenCalledWith(
+          "conv-1",
+          "Continue",
+          expect.objectContaining({}), // Includes signal property
+        );
+      });
+
+      // Should display the continuation response
+      await waitFor(() => {
+        expect(
+          screen.getByText("...and here is more information."),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables Continue button while streaming", async () => {
+      const user = userEvent.setup({ delay: null });
+
+      const mockConversations = {
+        items: [
+          {
+            id: "conv-1",
+            title: "Existing Conversation",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const mockMessages = {
+        conversation: mockConversations.items[0],
+        items: [
+          {
+            id: "msg-1",
+            role: "user" as const,
+            content: "Tell me more",
+            sequence_number: 1,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Here is some information...",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+              finish_reason: "length",
+            },
+          },
+        ],
+      };
+
+      mockListConversations.mockResolvedValue(mockConversations);
+      mockGetConversationMessages.mockResolvedValue(mockMessages);
+
+      // Mock a slow streaming response
+      mockStreamConversation.mockImplementationOnce(
+        async function* () {
+          yield { event: "token", data: "Streaming" };
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          yield { event: "token", data: "..." };
+          yield {
+            event: "done",
+            data: {
+              conversation_id: "conv-1",
+              message_id: "msg-4",
+              content: "Streaming...",
+              annotations: emptyAnnotations(),
+            },
+          };
+        } as unknown as typeof mockStreamConversation,
+      );
+
+      renderWithAuth();
+
+      // Wait and select conversation
+      await waitFor(() => {
+        expect(screen.getByText("Existing Conversation")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Existing Conversation"));
+
+      // Wait for messages to load
+      await waitFor(() => {
+        expect(
+          screen.getByText(/response truncated due to length/i),
+        ).toBeInTheDocument();
+      });
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      expect(continueButton).not.toBeDisabled();
+
+      await user.click(continueButton);
+
+      // Continue button should be disabled while streaming
+      await waitFor(() => {
+        expect(continueButton).toBeDisabled();
+      });
+    });
+
+    it("handles errors when Continue button is clicked", async () => {
+      const user = userEvent.setup({ delay: null });
+
+      const mockConversations = {
+        items: [
+          {
+            id: "conv-1",
+            title: "Existing Conversation",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      const mockMessages = {
+        conversation: mockConversations.items[0],
+        items: [
+          {
+            id: "msg-1",
+            role: "user" as const,
+            content: "Tell me more",
+            sequence_number: 1,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: null,
+          },
+          {
+            id: "msg-2",
+            role: "assistant" as const,
+            content: "Here is some information...",
+            sequence_number: 2,
+            created_at: "2024-01-01T00:00:00Z",
+            error: null,
+            annotations: {
+              thought: null,
+              sources: [],
+              tools: [],
+              memory_hits: [],
+              memory_saved: [],
+              failure: null,
+              finish_reason: "length",
+            },
+          },
+        ],
+      };
+
+      mockListConversations.mockResolvedValue(mockConversations);
+      mockGetConversationMessages.mockResolvedValue(mockMessages);
+      mockStreamConversation.mockImplementationOnce(
+        async function* () {
+          throw new Error("Network error");
+        } as unknown as typeof mockStreamConversation,
+      );
+
+      renderWithAuth();
+
+      // Wait and select conversation
+      await waitFor(() => {
+        expect(screen.getByText("Existing Conversation")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Existing Conversation"));
+
+      // Wait for messages to load
+      await waitFor(() => {
+        expect(
+          screen.getByText(/response truncated due to length/i),
+        ).toBeInTheDocument();
+      });
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await user.click(continueButton);
+
+      // Should display error message
+      await waitFor(() => {
+        expect(screen.getByText(/network error/i)).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -769,6 +769,49 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
     }
   };
 
+  // Handle continue button click for truncated responses
+  const handleContinue = useCallback(async () => {
+    if (!activeConversationId) return;
+
+    // Guard against concurrent sends while request is in flight
+    if (sendingMessage || isStreaming) return;
+
+    setSendingMessage(true);
+    setError(null);
+
+    try {
+      const userMessage: Message = {
+        id: `temp-user-${Date.now()}`,
+        role: "user",
+        content: "Continue",
+        sequence_number: -1,
+        created_at: new Date().toISOString(),
+        error: null,
+        annotations: null,
+      };
+      setMessages((prev) => [...prev, userMessage]);
+
+      pendingStreamMetaRef.current = {
+        startedWithoutActiveConversation: false,
+      };
+
+      // Stream the continuation
+      await stream(activeConversationId, "Continue", {});
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message === "UNAUTHORIZED") {
+          onLogout();
+          return;
+        }
+        setError(err.message);
+      } else {
+        setError("Failed to continue");
+      }
+    } finally {
+      setSendingMessage(false);
+    }
+  }, [activeConversationId, sendingMessage, isStreaming, stream, onLogout]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -911,6 +954,21 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
                                     />
                                   )}
                                 <MarkdownContent content={msg.content} />
+                                {msg.annotations?.finish_reason ===
+                                  "length" && (
+                                  <div className="mt-2 flex flex-col gap-2">
+                                    <div className="text-sm italic text-gray-500">
+                                      ... [Response truncated due to length]
+                                    </div>
+                                    <button
+                                      onClick={() => handleContinue()}
+                                      disabled={sendingMessage || isStreaming}
+                                      className="self-start text-xs bg-[#24453a] text-white px-3 py-1 rounded hover:bg-[#1a3428] transition-colors disabled:bg-[#d6cebd] disabled:cursor-not-allowed"
+                                    >
+                                      Continue
+                                    </button>
+                                  </div>
+                                )}
                               </>
                             ) : (
                               <div className="whitespace-pre-wrap">

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -966,8 +966,8 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
                                       .find(
                                         (message) =>
                                           message.role === "assistant" &&
-                                          message.annotations
-                                            ?.finish_reason === "length",
+                                          message.annotations?.finish_reason ===
+                                            "length",
                                       )?.id === msg.id && (
                                       <button
                                         onClick={() => handleContinue()}

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -960,13 +960,23 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
                                     <div className="text-sm italic text-gray-500">
                                       ... [Response truncated due to length]
                                     </div>
-                                    <button
-                                      onClick={() => handleContinue()}
-                                      disabled={sendingMessage || isStreaming}
-                                      className="self-start text-xs bg-[#24453a] text-white px-3 py-1 rounded hover:bg-[#1a3428] transition-colors disabled:bg-[#d6cebd] disabled:cursor-not-allowed"
-                                    >
-                                      Continue
-                                    </button>
+                                    {messages
+                                      .slice()
+                                      .reverse()
+                                      .find(
+                                        (message) =>
+                                          message.role === "assistant" &&
+                                          message.annotations
+                                            ?.finish_reason === "length",
+                                      )?.id === msg.id && (
+                                      <button
+                                        onClick={() => handleContinue()}
+                                        disabled={sendingMessage || isStreaming}
+                                        className="self-start text-xs bg-[#24453a] text-white px-3 py-1 rounded hover:bg-[#1a3428] transition-colors disabled:bg-[#d6cebd] disabled:cursor-not-allowed"
+                                      >
+                                        Continue
+                                      </button>
+                                    )}
                                   </div>
                                 )}
                               </>

--- a/apps/assistant-ui/src/hooks/useStreamingConversation.ts
+++ b/apps/assistant-ui/src/hooks/useStreamingConversation.ts
@@ -154,6 +154,26 @@ export function useStreamingConversation(
               }
               break;
 
+            case "meta": {
+              const metaData = event.data as {
+                model?: string;
+                usage?: any;
+                finish_reason?: string | null;
+              };
+              if (metaData.finish_reason !== undefined) {
+                currentAnnotations = {
+                  ...currentAnnotations,
+                  finish_reason: metaData.finish_reason,
+                };
+                setCurrentMessage((prev) =>
+                  prev
+                    ? { ...prev, annotations: { ...currentAnnotations } }
+                    : null,
+                );
+              }
+              break;
+            }
+
             case "done": {
               receivedDone = true;
               const doneData = event.data as StreamDoneData;

--- a/apps/assistant-ui/src/hooks/useStreamingConversation.ts
+++ b/apps/assistant-ui/src/hooks/useStreamingConversation.ts
@@ -157,7 +157,7 @@ export function useStreamingConversation(
             case "meta": {
               const metaData = event.data as {
                 model?: string;
-                usage?: any;
+                usage?: unknown;
                 finish_reason?: string | null;
               };
               if (metaData.finish_reason !== undefined) {

--- a/apps/assistant-ui/src/types/api.ts
+++ b/apps/assistant-ui/src/types/api.ts
@@ -81,7 +81,13 @@ export interface AssistantAnnotations {
 /**
  * SSE Event types for streaming responses
  */
-export type SSEEventType = "thought" | "token" | "tool_call" | "done" | "error";
+export type SSEEventType =
+  | "thought"
+  | "token"
+  | "tool_call"
+  | "meta"
+  | "done"
+  | "error";
 
 export interface SSEEvent {
   event: SSEEventType;

--- a/apps/assistant-ui/src/types/api.ts
+++ b/apps/assistant-ui/src/types/api.ts
@@ -75,6 +75,7 @@ export interface AssistantAnnotations {
   memory_hits: MemoryHitAnnotation[];
   memory_saved: MemorySavedAnnotation[];
   failure: FailureAnnotation | null;
+  finish_reason?: string | null;
 }
 
 /**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,13 +15,14 @@ Today the shipped system includes:
 - persisted assistant `annotations` for trust metadata and evidence
 - desktop trust UI with an inline trust row and evidence panel
 
-## Upcoming Scope (Active Development)
+## Recently Shipped
 
-We are currently rolling out real-time streaming for assistant replies:
+Real-time streaming for assistant replies is now complete:
 
-- **SSE Infrastructure:** Application-level SSE protocol and encoder to deliver structured events (`thought`, `token`, `done`, `error`) to the frontend.
-- **Incremental LLM Parsing:** `LLMService` support for consuming raw provider streams and parsing reasoning segments (thoughts) from user content.
-- **Delivery Verification:** A `/api/v1/chat/debug-stream` endpoint for verifying the end-to-end SSE delivery pipeline.
+- **SSE Infrastructure:** Application-level SSE protocol delivers structured events (`thought`, `token`, `tool_call`, `meta`, `done`, `error`) to the frontend.
+- **Incremental LLM Parsing:** `LLMService` consumes raw provider streams and parses reasoning segments (thoughts) from user content.
+- **Token Limit Handling:** Backend tracks `finish_reason` from LLM, persists in annotations, enables Continue button in UI when responses truncate due to length.
+- **Delivery Verification:** `/api/v1/chat/debug-stream` endpoint verifies end-to-end SSE delivery pipeline.
 
 ## High-Level Architecture
 
@@ -90,20 +91,20 @@ The stored payload can include:
 The frontend never regenerates this trust metadata client-side.
 It renders what the backend persisted on the assistant message.
 
-## Target Architecture: Streaming Response Lifecycle
+## Streaming Response Lifecycle
 
-Once fully integrated, the system will support real-time delivery of assistant responses using Server-Sent Events (SSE):
+The system supports real-time delivery of assistant responses using Server-Sent Events (SSE):
 
 1. **Incremental Parsing:** `LLMService` consumes the raw LLM stream, and `StreamParser` distinguishes between reasoning traces (thoughts) and user-visible content.
-2. **App-Level SSE Protocol:** The backend translates internal chunks into a structured app-level protocol (`thought`, `token`, `tool_call`, `done`, `error`) using `SSEEncoder`.
-3. **Persistence Timing:** User messages are persisted immediately to ensure durable history. Assistant messages are persisted only after the stream reaches a terminal state, capturing the full content and reasoning trace.
-4. **UI Updates:** The frontend hook consumes the SSE stream, updating the UI in real-time while distinguishing between reasoning and final content.
+2. **App-Level SSE Protocol:** The backend translates internal chunks into a structured app-level protocol (`thought`, `token`, `tool_call`, `meta`, `done`, `error`) using `SSEEncoder`.
+3. **Token Limit Handling:** Backend enforces `LLM_MAX_TOKENS` (default: 1024), captures `finish_reason` from LLM, persists in `AssistantAnnotations`. When `finish_reason === 'length'`, frontend displays truncation indicator and Continue button.
+4. **Persistence Timing:** User messages are persisted immediately to ensure durable history. Assistant messages are persisted only after the stream reaches a terminal state, capturing the full content, reasoning trace, and finish_reason.
+5. **UI Updates:** The frontend hook consumes the SSE stream, updating the UI in real-time while distinguishing between reasoning and final content.
 
 ## Current Boundaries
 
 The shipped architecture intentionally does not include:
 
-- full end-to-end streaming of conversation replies (currently in progress)
 - image, audio, or video generation
 - Google Drive ingestion
 - household shared-memory features


### PR DESCRIPTION
- Add finish_reason field to AssistantAnnotations model
- Capture and persist finish_reason from LLM responses in streaming
- Add llm_max_tokens setting with default of 1024
- Use llm_max_tokens as default in request models
- Display truncation indicator when finish_reason='length' in UI
- Add Continue button for truncated responses
- Add backend tests for finish_reason capture and persistence

This makes response truncation observable in the UI and provides a mechanism for users to continue truncated responses.

## Documentation

Updated project documentation to reflect streaming responses with token-limit handling:

- **.github/copilot-instructions.md:** React version corrected (18→19), added LLM_MAX_TOKENS and truncation recovery to backend capabilities
- **.env.example:** Added LLM_MAX_TOKENS configuration option (default: 1024) with description
- **docs/ARCHITECTURE.md:** Updated "Upcoming Scope" → "Recently Shipped", added token-limit handling to streaming lifecycle, removed "currently in progress" from boundaries
- **README.md:** Added streaming responses feature with token-limit handling to "What Exists Today", added "For AI Agents" section linking agent configuration files

All documentation now accurately reflects the completed feature set.
