### PR TITLE
feat(streaming): add stop control for active responses

### DIFF
--- a/apps/assistant-backend/README.md
+++ b/apps/assistant-backend/README.md
@@ -15,6 +15,7 @@ Chroma for retrieval support, and an external OpenAI-compatible LLM server for i
 - **User API** — retrieves the currently authenticated user
 - **Shared LLM completion seam** — one typed path powers both `/api/v1/chat/completions` and conversation replies
 - **Conversation orchestration** — creates conversations, appends messages, and persists terminal assistant failures instead of dropping outcomes
+- **Streaming conversation replies** — conversation endpoints support Server-Sent Events when `stream: true`, including thought traces, tool lifecycle events, terminal metadata, and cancellation-aware persistence
 - **Bounded context assembly** — conversation replies use recent turns, one latest saved summary, and active per-user durable facts from PostgreSQL
 - **Canonical memory storage** — conversation summaries and durable facts are stored in Postgres and mirrored into Chroma only for retrieval support
 - **Tool orchestration** — `ToolFactory` and `ToolService` expose an explicit allowlist with a bounded model-native tool loop
@@ -37,9 +38,9 @@ Chroma for retrieval support, and an external OpenAI-compatible LLM server for i
 | `GET` | `/health` | Health check |
 | `POST` | `/api/v1/chat/completions` | Send a chat message and receive an LLM response |
 | `GET` | `/api/v1/conversations` | List all conversations for the current user |
-| `POST` | `/api/v1/conversations/with-message` | Create a new conversation with an initial message |
+| `POST` | `/api/v1/conversations/with-message` | Create a new conversation with an initial message; returns JSON or SSE when `stream=true` |
 | `GET` | `/api/v1/conversations/{id}/messages` | Get all messages in a conversation |
-| `POST` | `/api/v1/conversations/{id}/messages` | Add a message to an existing conversation |
+| `POST` | `/api/v1/conversations/{id}/messages` | Add a message to an existing conversation; returns JSON or SSE when `stream=true` |
 
 ---
 

--- a/apps/assistant-ui/src/components/ConversationsChat.test.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.test.tsx
@@ -336,6 +336,80 @@ describe("ConversationsChat", () => {
       });
     });
 
+    it("shows a Stop button while streaming and aborts the stream when clicked", async () => {
+      const user = userEvent.setup({ delay: null });
+      mockListConversations.mockResolvedValue({ items: [] });
+
+      let receivedSignal: AbortSignal | undefined;
+      let releaseStream!: () => void;
+      const streamStopped = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+
+      mockStreamConversation.mockImplementationOnce(async function* (
+        _conversationId: string | null,
+        _content: string,
+        options?: {
+          temperature?: number;
+          max_tokens?: number;
+          signal?: AbortSignal;
+        },
+      ): AsyncGenerator<SSEEvent, void, unknown> {
+        receivedSignal = options?.signal;
+        yield { event: "token" as const, data: "Working" };
+
+        if (receivedSignal?.aborted) {
+          return;
+        }
+
+        await new Promise<void>((resolve) => {
+          receivedSignal?.addEventListener(
+            "abort",
+            () => {
+              releaseStream();
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      } as unknown as typeof mockStreamConversation);
+
+      renderWithAuth();
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText(
+            /type a message to start a new conversation/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText(
+        /type a message to start a new conversation/i,
+      );
+      await user.type(input, "Hello");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /stop/i }),
+        ).toBeInTheDocument();
+      });
+
+      const stopButton = screen.getByRole("button", { name: /stop/i });
+      await user.click(stopButton);
+
+      await streamStopped;
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /stop/i }),
+        ).not.toBeInTheDocument();
+      });
+      expect(receivedSignal?.aborted).toBe(true);
+      expect((input as HTMLInputElement).value).toBe("Hello");
+    });
+
     it("shows welcome message when no conversation is selected", async () => {
       mockListConversations.mockResolvedValue({ items: [] });
 

--- a/apps/assistant-ui/src/components/ConversationsChat.tsx
+++ b/apps/assistant-ui/src/components/ConversationsChat.tsx
@@ -1071,11 +1071,18 @@ export function ConversationsChat({ onLogout }: ConversationsChatProps) {
               className="flex-1 border border-[#ded6c7] rounded px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#24453a] disabled:bg-[#f6f2ea]"
             />
             <button
-              onClick={handleSendMessage}
-              disabled={sendingMessage || !inputMessage.trim()}
-              className="bg-[#24453a] text-white px-6 py-2 rounded hover:bg-[#1a3428] transition-colors disabled:bg-[#d6cebd] disabled:cursor-not-allowed"
+              type="button"
+              onClick={isStreaming ? stop : handleSendMessage}
+              disabled={
+                isStreaming ? false : sendingMessage || !inputMessage.trim()
+              }
+              className={`px-6 py-2 rounded transition-colors disabled:cursor-not-allowed ${
+                isStreaming
+                  ? "bg-[#a54034] text-white hover:bg-[#8a3328]"
+                  : "bg-[#24453a] text-white hover:bg-[#1a3428] disabled:bg-[#d6cebd]"
+              }`}
             >
-              {sendingMessage ? "Sending..." : "Send"}
+              {isStreaming ? "Stop" : sendingMessage ? "Sending..." : "Send"}
             </button>
           </div>
         </div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,9 @@ Real-time streaming for assistant replies is now complete:
 
 - **SSE Infrastructure:** Application-level SSE protocol delivers structured events (`thought`, `token`, `tool_call`, `meta`, `done`, `error`) to the frontend.
 - **Incremental LLM Parsing:** `LLMService` consumes raw provider streams and parses reasoning segments (thoughts) from user content.
+- **Streaming Tool Loop:** tool calls emitted during streaming are executed in-stream, their results are fed back to the model, and tool lifecycle state is surfaced in the UI.
 - **Token Limit Handling:** Backend tracks `finish_reason` from LLM, persists in annotations, enables Continue button in UI when responses truncate due to length.
+- **Cancellation Support:** the chat composer exposes a `Stop` button during active streams, which aborts the SSE request and lets the backend persist truthful terminal state.
 - **Delivery Verification:** `/api/v1/chat/debug-stream` endpoint verifies end-to-end SSE delivery pipeline.
 
 ## High-Level Architecture
@@ -99,7 +101,8 @@ The system supports real-time delivery of assistant responses using Server-Sent 
 2. **App-Level SSE Protocol:** The backend translates internal chunks into a structured app-level protocol (`thought`, `token`, `tool_call`, `meta`, `done`, `error`) using `SSEEncoder`.
 3. **Token Limit Handling:** Backend enforces `LLM_MAX_TOKENS` (default: 1024), captures `finish_reason` from LLM, persists in `AssistantAnnotations`. When `finish_reason === 'length'`, frontend displays truncation indicator and Continue button.
 4. **Persistence Timing:** User messages are persisted immediately to ensure durable history. Assistant messages are persisted only after the stream reaches a terminal state, capturing the full content, reasoning trace, and finish_reason.
-5. **UI Updates:** The frontend hook consumes the SSE stream, updating the UI in real-time while distinguishing between reasoning and final content.
+5. **Streaming Tool Execution:** Conversation streaming can execute allowlisted tools between stream rounds, emit tool lifecycle events, and continue the assistant turn with tool results included in prompt state.
+6. **UI Updates:** The frontend hook consumes the SSE stream, updating the UI in real-time while distinguishing between reasoning and final content. While a stream is active, the composer shows a `Stop` action that aborts the request.
 
 ## Current Boundaries
 

--- a/docs/STREAMING_RESPONSES_PRD.md
+++ b/docs/STREAMING_RESPONSES_PRD.md
@@ -1,5 +1,27 @@
 # Streaming Responses PRD
 
+## Status
+
+Streaming responses are now fully implemented relative to the goals in this
+PRD.
+
+Shipped behavior includes:
+
+- SSE delivery for conversation creation and follow-up message endpoints when
+  `stream: true`
+- real-time `thought`, `token`, `tool_call`, `meta`, `done`, and `error`
+  events
+- in-stream tool execution with bounded multi-round continuation
+- immediate user-message persistence and deferred assistant persistence
+- persistence of reasoning traces, tool metadata, terminal failures, and
+  `finish_reason`
+- UI handling for thought traces, tool lifecycle state, truncation recovery via
+  `Continue`, and user-initiated cancellation via `Stop`
+
+The remaining value of this document is as an implementation record and design
+reference. Any previous "remaining gaps" below have been updated to match the
+shipped system.
+
 ## Summary
 
 This document defines the implementation plan for real-time streaming
@@ -31,7 +53,8 @@ the user as it is generated.
 
 ## Problem Statement
 
-The current backend is entirely non-streaming. When a user sends a message:
+Before this work, the backend was entirely non-streaming. When a user sent a
+message:
 1. The backend makes a blocking call to the LLM.
 2. The LLM generates the full response (often taking 10-60+ seconds).
 3. The backend returns the final result.
@@ -51,8 +74,8 @@ while being more efficient than long polling.
 ### Tool calls must be handled carefully
 Streaming complicates tool-calling loops. The system must decide when to
 emit tokens to the user and when to pause for tool execution.
-Initially, we may stream the reasoning/content until a tool call is
-identified, execute the tool, and then continue streaming the next turn.
+The shipped implementation streams reasoning/content until a tool call is
+identified, executes the tool, and then continues streaming the next turn.
 
 ### Persistence distinguishes user vs. assistant messages
 To maintain a consistent history while preserving failure recovery semantics,
@@ -113,6 +136,7 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
 - Show an active streaming state for the latest assistant message.
 - Render content as it arrives.
 - Distinguish between reasoning traces and final content.
+- Let the user stop an active stream without leaving the conversation.
 
 ## Architecture Changes
 
@@ -124,9 +148,10 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
 ### Existing areas touched
 - `apps/assistant-backend/src/assistant/services/llm_service.py`
 - `apps/assistant-backend/src/assistant/services/conversation_service.py`
-- `apps/assistant-backend/src/assistant/routers/chat.py`
+- `apps/assistant-backend/src/assistant/routers/conversations.py`
 - `apps/assistant-ui/src/lib/api.ts`
-- `apps/assistant-ui/src/components/Chat.tsx`
+- `apps/assistant-ui/src/hooks/useStreamingConversation.ts`
+- `apps/assistant-ui/src/components/ConversationsChat.tsx`
 
 ## Rollout Plan
 
@@ -165,27 +190,30 @@ Update `Chat.tsx` and `ConversationsChat.tsx` to:
   - Keep persistence guarantees: user message immediate, assistant message deferred to
     terminal state.
 
-## Current Status & Remaining Gaps
+## Current Status
 
-The current implementation supports token/thought streaming and persistence lifecycle,
-but it is not yet complete relative to the product goals. Remaining work:
+The implementation now covers the original product goals:
 
-- **Streaming tool execution is incomplete:** tool calls detected during streaming are
-  not yet executed in-stream.
-- **Fallback behavior masks failures:** UI fallback from stream to non-stream can hide
-  stream-path bugs and produce confusing duplicate failures.
-- **Token-limit handling needs operator controls:** truncation (`finish_reason=length`)
-  is observable, but default limits and user-facing behavior for truncation recovery
-  need to be finalized.
-- **End-to-end test coverage gaps:** add backend router/service tests and frontend
-  integration tests for:
-  - streaming with tool calls
-  - interrupted streams with partial assistant output
-  - terminal error handling without silent fallback
-  - `done` payload integrity (message id, annotations, usage when available)
-- **Operational guidance:** document model/endpoint requirements (OpenAI-compatible
-  `/v1/chat/completions`) and expected behavior when backend/model does not support the
-  configured path.
+- **Streaming delivery is live:** conversation endpoints support JSON or SSE
+  delivery, selected by the request body's `stream: true` flag.
+- **Streaming tool execution is complete:** tool calls detected during
+  streaming are executed in-stream, tool results are fed back into the LLM,
+  and the assistant turn continues until a terminal state.
+- **Persistence lifecycle is complete:** the user turn is persisted
+  immediately; the assistant turn is persisted only when the stream reaches a
+  terminal success, cancellation, or error state.
+- **Token-limit handling is live:** `finish_reason` is captured, persisted, and
+  surfaced in the UI, including `Continue` affordances for
+  `finish_reason=\"length\"`.
+- **Cancellation support is live:** the frontend can stop an active stream,
+  which aborts the SSE request and lets the backend persist partial output in a
+  terminal error state when needed.
+- **Test coverage exists across layers:** backend router/service tests and
+  frontend integration tests cover successful streams, tool calls,
+  interruptions, cancellation, terminal errors, and `done` payload handling.
+- **Operational guidance exists:** the backend expects an OpenAI-compatible
+  `/v1/chat/completions` endpoint for both non-streaming and streaming
+  completions.
 
 ## Testing Strategy
 
@@ -193,6 +221,8 @@ but it is not yet complete relative to the product goals. Remaining work:
 - **Backend:** Test persistence of interrupted streams.
 - **Frontend:** Verify UI responsiveness during streaming.
 - **Frontend:** Test reconnection/error handling for dropped streams.
+- **Frontend:** Test user-initiated cancellation through the visible `Stop`
+  control.
 
 ## Open Questions & Proposed Answers
 
@@ -220,7 +250,9 @@ type.
 **Recommendation:** Yes.
 - **Implementation:** If the frontend closes the SSE connection, the backend
   should detect the `ClientDisconnect` (standard in FastAPI/Starlette) and
-  cancel the underlying LLM request to save local compute resources.
+  cancel the underlying LLM request to save local compute resources. The
+  shipped UI exposes this behavior through a visible `Stop` button while a
+  response is streaming.
 
 ## Technical Flow & Wiring
 


### PR DESCRIPTION
## Summary
- add a visible Stop button to the conversation composer while a response is streaming
- route Stop to the existing abort path so users can cancel generation without leaving the chat
- add a UI test covering the Stop control and stream abort behavior

## Validation
- npm run format
- npm run lint
- npm run typecheck
- npm run test:coverage
- npm run build